### PR TITLE
New YETI blue oklch values

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -8,17 +8,17 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-	--yeti-50: oklch(0.965 0.005 232.04);
-	--yeti-100: oklch(0.95 0.025 232.04);
-	--yeti-200: oklch(0.905 0.055 232.04);
-	--yeti-300: oklch(0.83 0.1 232.04);
-	--yeti-400: oklch(0.7366 0.114 232.04);
-	--yeti-500: oklch(0.685 0.13 232.04);
-	--yeti-600: oklch(0.595 0.115 232.04);
-	--yeti-700: oklch(0.5 0.1 232.04);
-	--yeti-800: oklch(0.435 0.085 232.04);
-	--yeti-900: oklch(0.36 0.065 232.04);
-	--yeti-950: oklch(0.16 0.0326 232.04);
+	--yeti-50: oklch(0.978 0.0092 232.36);
+	--yeti-100: oklch(0.9507 0.0201 238.67);
+	--yeti-200: oklch(0.8973 0.0443 232.42);
+	--yeti-300: oklch(0.8135 0.0831 232.31);
+	--yeti-400: oklch(0.7366 0.1138 232.04);
+	--yeti-500: oklch(0.6475 0.129 236.22);
+	--yeti-600: oklch(0.5538 0.1209 240.68);
+	--yeti-700: oklch(0.4747 0.1025 241.12);
+	--yeti-800: oklch(0.4225 0.0866 240.08);
+	--yeti-900: oklch(0.3772 0.0722 240.33);
+	--yeti-950: oklch(0.2858 0.0525 242.35);
 
 	--radius: 0.5rem;
 	--background: var(--color-white);
@@ -138,6 +138,7 @@
 	--color-yeti-700: var(--yeti-700);
 	--color-yeti-800: var(--yeti-800);
 	--color-yeti-900: var(--yeti-900);
+	--color-yeti-950: var(--yeti-950);
 
 	--animate-accordion-down: accordion-down 0.2s ease-out;
 	--animate-accordion-up: accordion-up 0.2s ease-out;


### PR DESCRIPTION
Updated the existing `oklch` values to the new ones in the following color palette:

![image](https://github.com/user-attachments/assets/f2299a09-c5ed-48ea-bed6-408b18fc7b2b)
