### PR TITLE
feat: outreach leaderboard

### DIFF
--- a/apps/basecamp/src/bot/bot.commands.ts
+++ b/apps/basecamp/src/bot/bot.commands.ts
@@ -108,6 +108,9 @@ export class BotCommands {
       outreachString += `\n- 🎉 Veteran minimum achieved! Great work!`;
     }
 
+    outreachString +=
+      '\n*Please reach out to Ms. I in the <#408795997410426880> if you feel our record of your outreach is incorrect*';
+
     return interaction.reply(outreachString);
   }
 }

--- a/apps/basecamp/src/bot/bot.commands.ts
+++ b/apps/basecamp/src/bot/bot.commands.ts
@@ -27,7 +27,7 @@ export class BotCommands {
 
   @SlashCommand({
     name: 'signin',
-    description: 'Sign in to the server',
+    description: 'Sign in to a YETI meeting at the zone',
   })
   public async onSignIn(@Context() [interaction]: SlashCommandContext) {
     const nickname = await this.getNickname(interaction);
@@ -51,7 +51,7 @@ export class BotCommands {
 
   @SlashCommand({
     name: 'signout',
-    description: 'Sign out of the server',
+    description: 'Sign out of a YETI meeting at the zone',
   })
   public async onSignOut(@Context() [interaction]: SlashCommandContext) {
     const nickname = await this.getNickname(interaction);
@@ -75,7 +75,7 @@ export class BotCommands {
 
   @SlashCommand({
     name: 'outreach',
-    description: 'Get outreach for a user',
+    description: 'Get your current outreach progress',
   })
   public async onOutreach(@Context() [interaction]: SlashCommandContext) {
     const nickname = await this.getNickname(interaction);
@@ -112,5 +112,49 @@ export class BotCommands {
       '\n*Please reach out to Ms. I in the <#408795997410426880> if you feel our record of your outreach is incorrect*';
 
     return interaction.reply(outreachString);
+  }
+
+  @SlashCommand({
+    name: 'leaderboard',
+    description: 'Show the top 5 members by outreach hours',
+  })
+  public async onLeaderboard(@Context() [interaction]: SlashCommandContext) {
+    const leaderboard = await this.outreachService.getTopMembersByHours(5);
+
+    if (!leaderboard || leaderboard.length === 0) {
+      return interaction.reply('No outreach data found');
+    }
+
+    let leaderboardString = ':trophy: **Outreach Leaderboard** :trophy:\n\n';
+
+    leaderboard.forEach((entry, index) => {
+      const rank = index + 1;
+      let prefix = '';
+
+      // Medal emojis for top 3, numbers for 4th and 5th
+      switch (rank) {
+        case 1:
+          prefix = ':first_place_medal:';
+          break;
+        case 2:
+          prefix = ':second_place_medal:';
+          break;
+        case 3:
+          prefix = ':third_place_medal:';
+          break;
+        case 4:
+          prefix = '4.';
+          break;
+        case 5:
+          prefix = '5.';
+          break;
+      }
+
+      leaderboardString += `${prefix} **${entry.userName}** - ${entry.totalHours} hours\n`;
+    });
+
+    leaderboardString += '\n*Updated in real-time from outreach records*';
+
+    return interaction.reply(leaderboardString);
   }
 }

--- a/apps/basecamp/src/data/outreach/outreach.service.spec.ts
+++ b/apps/basecamp/src/data/outreach/outreach.service.spec.ts
@@ -5,6 +5,16 @@ import { ConfigService } from '@nestjs/config';
 
 describe('OutreachService', () => {
   let service: OutreachService;
+  let sheetService: jest.Mocked<SheetService>;
+
+  const mockSheetData = [
+    ['2024-01-01', 'John Doe', 'Event 1', 'Workshop', '10'],
+    ['2024-01-02', 'Jane Smith', 'Event 2', 'Competition', '15'],
+    ['2024-01-03', 'John Doe', 'Event 3', 'Workshop', '5'],
+    ['2024-01-04', 'Bob Johnson', 'Event 4', 'Outreach', '20'],
+    ['2024-01-05', 'Jane Smith', 'Event 5', 'Workshop', '8'],
+    ['2024-01-06', 'Alice Brown', 'Event 6', 'Competition', '12'],
+  ];
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -13,7 +23,7 @@ describe('OutreachService', () => {
         {
           provide: SheetService,
           useValue: {
-            getSheetValues: jest.fn().mockReturnValue([]),
+            getSheetValues: jest.fn(),
           },
         },
         {
@@ -26,9 +36,167 @@ describe('OutreachService', () => {
     }).compile();
 
     service = module.get<OutreachService>(OutreachService);
+    sheetService = module.get(SheetService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getUserOutreach', () => {
+    it('should return user outreach data when valid data exists', async () => {
+      sheetService.getSheetValues.mockResolvedValue(mockSheetData);
+
+      const result = await service.getUserOutreach('John Doe');
+
+      expect(result).toEqual([
+        {
+          date: '2024-01-01',
+          userName: 'John Doe',
+          event: 'Event 1',
+          eventType: 'Workshop',
+          hours: 10,
+        },
+        {
+          date: '2024-01-03',
+          userName: 'John Doe',
+          event: 'Event 3',
+          eventType: 'Workshop',
+          hours: 5,
+        },
+      ]);
+    });
+
+    it('should return null when no data exists', async () => {
+      sheetService.getSheetValues.mockResolvedValue(null);
+
+      const result = await service.getUserOutreach('John Doe');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when user has no outreach', async () => {
+      sheetService.getSheetValues.mockResolvedValue(mockSheetData);
+
+      const result = await service.getUserOutreach('NonExistentUser');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getTopMembersByHours', () => {
+    it('should return top 5 members sorted by total hours in descending order', async () => {
+      sheetService.getSheetValues.mockResolvedValue(mockSheetData);
+
+      const result = await service.getTopMembersByHours(5);
+
+      expect(result).toEqual([
+        { userName: 'Jane Smith', totalHours: 23 },
+        { userName: 'Bob Johnson', totalHours: 20 },
+        { userName: 'John Doe', totalHours: 15 },
+        { userName: 'Alice Brown', totalHours: 12 },
+      ]);
+    });
+
+    it('should return top 3 members when limit is 3', async () => {
+      sheetService.getSheetValues.mockResolvedValue(mockSheetData);
+
+      const result = await service.getTopMembersByHours(3);
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual([
+        { userName: 'Jane Smith', totalHours: 23 },
+        { userName: 'Bob Johnson', totalHours: 20 },
+        { userName: 'John Doe', totalHours: 15 },
+      ]);
+    });
+
+    it('should return empty array when no data exists', async () => {
+      sheetService.getSheetValues.mockResolvedValue(null);
+
+      const result = await service.getTopMembersByHours(5);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when sheet data is empty', async () => {
+      sheetService.getSheetValues.mockResolvedValue([]);
+
+      const result = await service.getTopMembersByHours(5);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle single user with multiple entries correctly', async () => {
+      const singleUserData = [
+        ['2024-01-01', 'John Doe', 'Event 1', 'Workshop', '10'],
+        ['2024-01-02', 'John Doe', 'Event 2', 'Competition', '15'],
+        ['2024-01-03', 'John Doe', 'Event 3', 'Workshop', '5'],
+      ];
+
+      sheetService.getSheetValues.mockResolvedValue(singleUserData);
+
+      const result = await service.getTopMembersByHours(5);
+
+      expect(result).toEqual([{ userName: 'John Doe', totalHours: 30 }]);
+    });
+
+    it('should handle users with same total hours correctly', async () => {
+      const tiedData = [
+        ['2024-01-01', 'User A', 'Event 1', 'Workshop', '10'],
+        ['2024-01-02', 'User B', 'Event 2', 'Competition', '10'],
+        ['2024-01-03', 'User C', 'Event 3', 'Workshop', '10'],
+      ];
+
+      sheetService.getSheetValues.mockResolvedValue(tiedData);
+
+      const result = await service.getTopMembersByHours(3);
+
+      expect(result).toHaveLength(3);
+      expect(result.every((entry) => entry.totalHours === 10)).toBe(true);
+    });
+
+    it('should return default limit of 5 when no limit is specified', async () => {
+      sheetService.getSheetValues.mockResolvedValue(mockSheetData);
+
+      const result = await service.getTopMembersByHours();
+
+      expect(result).toHaveLength(4); // Only 4 unique users in mock data
+      expect(result).toEqual([
+        { userName: 'Jane Smith', totalHours: 23 },
+        { userName: 'Bob Johnson', totalHours: 20 },
+        { userName: 'John Doe', totalHours: 15 },
+        { userName: 'Alice Brown', totalHours: 12 },
+      ]);
+    });
+
+    it('should handle error gracefully and return empty array', async () => {
+      sheetService.getSheetValues.mockRejectedValue(
+        new Error('Sheet API error'),
+      );
+
+      const result = await service.getTopMembersByHours(5);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should correctly sum hours for users with multiple entries', async () => {
+      const multipleEntriesData = [
+        ['2024-01-01', 'John Doe', 'Event 1', 'Workshop', '5'],
+        ['2024-01-02', 'John Doe', 'Event 2', 'Competition', '10'],
+        ['2024-01-03', 'John Doe', 'Event 3', 'Workshop', '15'],
+        ['2024-01-04', 'Jane Smith', 'Event 4', 'Outreach', '8'],
+        ['2024-01-05', 'Jane Smith', 'Event 5', 'Workshop', '12'],
+      ];
+
+      sheetService.getSheetValues.mockResolvedValue(multipleEntriesData);
+
+      const result = await service.getTopMembersByHours(5);
+
+      expect(result).toEqual([
+        { userName: 'John Doe', totalHours: 30 },
+        { userName: 'Jane Smith', totalHours: 20 },
+      ]);
+    });
   });
 });

--- a/apps/basecamp/src/data/outreach/outreach.service.ts
+++ b/apps/basecamp/src/data/outreach/outreach.service.ts
@@ -57,4 +57,47 @@ export class OutreachService {
       return null;
     }
   }
+
+  async getTopMembersByHours(limit: number = 5) {
+    try {
+      const sheet = await this.sheetService.getSheetValues(
+        this.outreachSheetId,
+        'OutreachInput!A:E',
+      );
+
+      if (!sheet) {
+        return [];
+      }
+
+      // Parse all outreach data
+      const outreachData = sheet.map((row) =>
+        OutreachColumnSchema.parse({
+          date: row[0],
+          userName: row[1],
+          event: row[2],
+          eventType: row[3],
+          hours: Number(row[4]),
+        }),
+      );
+
+      // Group by user and sum hours
+      const userHoursMap = new Map<string, number>();
+
+      outreachData.forEach((entry) => {
+        const currentHours = userHoursMap.get(entry.userName) || 0;
+        userHoursMap.set(entry.userName, currentHours + entry.hours);
+      });
+
+      // Convert to array and sort by total hours (descending)
+      const leaderboard = Array.from(userHoursMap.entries())
+        .map(([userName, totalHours]) => ({ userName, totalHours }))
+        .sort((a, b) => b.totalHours - a.totalHours)
+        .slice(0, limit);
+
+      return leaderboard;
+    } catch (error) {
+      console.error('Error getting leaderboard:', error);
+      return [];
+    }
+  }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the outreach tracking functionality in the `apps/basecamp` project. The changes include updates to bot commands for clarity, the addition of a leaderboard feature to display top outreach contributors, and expanded test coverage for the `OutreachService`. These updates improve user experience and ensure robust functionality.

### Bot Command Updates:
* Updated descriptions for `signin`, `signout`, and `outreach` commands to provide clearer context about their usage. (`apps/basecamp/src/bot/bot.commands.ts`: [[1]](diffhunk://#diff-128b8cecf8588123c34aa5db09c2997db3b74d0fb2f6a7d7cba1f620625f9db5L30-R30) [[2]](diffhunk://#diff-128b8cecf8588123c34aa5db09c2997db3b74d0fb2f6a7d7cba1f620625f9db5L54-R54) [[3]](diffhunk://#diff-128b8cecf8588123c34aa5db09c2997db3b74d0fb2f6a7d7cba1f620625f9db5L78-R78)
* Added a new `leaderboard` command to display the top 5 members based on outreach hours. (`apps/basecamp/src/bot/bot.commands.ts`: [apps/basecamp/src/bot/bot.commands.tsR111-R159](diffhunk://#diff-128b8cecf8588123c34aa5db09c2997db3b74d0fb2f6a7d7cba1f620625f9db5R111-R159))

### Outreach Service Enhancements:
* Implemented `getTopMembersByHours` method to calculate and return the top contributors based on outreach hours, including error handling and sorting logic. (`apps/basecamp/src/data/outreach/outreach.service.ts`: [apps/basecamp/src/data/outreach/outreach.service.tsR60-R102](diffhunk://#diff-389852405963359971fb1c279c67326a025028946a72fbe52c9d9277c5d7341bR60-R102))

### Test Coverage Expansion:
* Added mock data and tests for `OutreachService` to validate the functionality of `getUserOutreach` and `getTopMembersByHours`. Tests include scenarios for valid data, empty data, errors, and edge cases like ties and multiple entries per user. (`apps/basecamp/src/data/outreach/outreach.service.spec.ts`: [[1]](diffhunk://#diff-05af742821b32576b7e25aeb335943db5e262ec862bc322350b9ecf9fca38164R8-R17) [[2]](diffhunk://#diff-05af742821b32576b7e25aeb335943db5e262ec862bc322350b9ecf9fca38164L16-R26) [[3]](diffhunk://#diff-05af742821b32576b7e25aeb335943db5e262ec862bc322350b9ecf9fca38164R39-R201)