### PR TITLE
add 30 min grace period to double sign in flow and inform user about half credits

### DIFF
--- a/apps/basecamp/src/data/attendance/attendance.service.ts
+++ b/apps/basecamp/src/data/attendance/attendance.service.ts
@@ -127,7 +127,7 @@ export class AttendanceService {
       const lastDate = new Date(lastOperation.date);
       const currentDate = new Date();
 
-      if (currentDate.getTime() - lastDate.getTime() < 1000 * 60 * 60 * 3) {
+      if (currentDate.getTime() - lastDate.getTime() < 1000 * 60 * 60 * 3.5) {
         return {
           success: false,
           message: 'You are currently signed in.',

--- a/apps/basecamp/src/data/attendance/attendance.service.ts
+++ b/apps/basecamp/src/data/attendance/attendance.service.ts
@@ -134,18 +134,25 @@ export class AttendanceService {
         };
       } else {
         try {
-          await this.performAttendanceOperation(
+          const result = await this.performAttendanceOperation(
             discordId,
             discordName,
             guildId,
             'signOut',
             new Date(currentDate.getTime() - 1000 * 60 * 60 * 1.5),
           );
+
+          if (result) {
+            return {
+              success: false,
+              message: 'You signed in last meeting but did not sign out. You will be credited for 1.5 hours of attendance for that meeting.'
+            }
+          }
         } catch (error) {
           this.logger.error(`Failed to sign in: ${error}`);
           return {
             success: false,
-            message: 'Failed to sign in.',
+            message: "You have signed in successfully, but you did not sign out last time, so you will receive half credit for the previous meeting",
           };
         }
       }


### PR DESCRIPTION
If a user signs in twice in a row within 3 hours (length of a typical meeting), they are told they are already signed in. this has been extended to 3.5 hours to allow for if someone arrives a little early or leaves a little late.

If a user signs in twice in a row after more than this grace period, they will be credited for 1.5 hours (half the meeting) since we can't verify when they left.