### PR TITLE
Fix rounding and precision for attendance command

### DIFF
--- a/apps/basecamp/src/bot/bot.commands.ts
+++ b/apps/basecamp/src/bot/bot.commands.ts
@@ -195,7 +195,7 @@ export class BotCommands {
       );
 
       const hoursString = Math.round(hours);
-      const hoursPercentage = Math.round((hours / TOTAL_HOURS) * 100);
+      const hoursPercentage = ((hours / TOTAL_HOURS) * 100);
       const hoursPercentageString = hoursPercentage.toFixed(2);
 
       if (hours >= LEADERSHIP_REQUIRED_HOURS) {

--- a/apps/basecamp/src/bot/bot.commands.ts
+++ b/apps/basecamp/src/bot/bot.commands.ts
@@ -194,7 +194,7 @@ export class BotCommands {
         interaction.user.id,
       );
 
-      const hoursString = Math.round(hours);
+      const hoursString = Math.floor(hours);
       const hoursPercentage = ((hours / TOTAL_HOURS) * 100);
       const hoursPercentageString = hoursPercentage.toFixed(2);
 

--- a/apps/basecamp/src/bot/bot.commands.ts
+++ b/apps/basecamp/src/bot/bot.commands.ts
@@ -193,9 +193,11 @@ export class BotCommands {
       const hours = await this.attendanceService.getUserHours(
         interaction.user.id,
       );
-
+      //Floors hours to the nearest integer
       const hoursString = Math.floor(hours);
+      //Calculates hoursPercentage without rounding anything
       const hoursPercentage = ((hours / TOTAL_HOURS) * 100);
+      //Rounds hoursPercentage to 2 decimal places
       const hoursPercentageString = hoursPercentage.toFixed(2);
 
       if (hours >= LEADERSHIP_REQUIRED_HOURS) {


### PR DESCRIPTION
- Hours are now floored to the nearest integer
- hoursPercentage is calculated without any rounding
- hoursPercentage is displayed with a precision of 2 decimal points
- Comments added to make the code a bit clearer