### PR TITLE
Potential fix for code scanning alert no. 12: Server-side request forgery

### DIFF
--- a/apps/web/lib/data/thebluealliance/match.ts
+++ b/apps/web/lib/data/thebluealliance/match.ts
@@ -79,7 +79,7 @@ export async function seedMatches(eventKey: string) {
 	// Validate eventKey
 	const eventKeySchema = z
 		.string()
-		.regex(/^[a-zA-Z0-9_\-]+$/, "Invalid event key format");
+		.regex(/^[a-zA-Z0-9_-]+$/, "Invalid event key format");
 	const parsedEventKey = eventKeySchema.safeParse(eventKey);
 	if (!parsedEventKey.success) {
 		throw new Error("Invalid event key");

--- a/apps/web/lib/data/thebluealliance/match.ts
+++ b/apps/web/lib/data/thebluealliance/match.ts
@@ -76,8 +76,10 @@ function parseMatchScoreBreakdown(
 }
 
 export async function seedMatches(eventKey: string) {
-	// Validate eventKey to prevent SSRF
-	const eventKeySchema = z.string().regex(/^[a-zA-Z0-9_\-]+$/, "Invalid event key format");
+	// Validate eventKey
+	const eventKeySchema = z
+		.string()
+		.regex(/^[a-zA-Z0-9_\-]+$/, "Invalid event key format");
 	const parsedEventKey = eventKeySchema.safeParse(eventKey);
 	if (!parsedEventKey.success) {
 		throw new Error("Invalid event key");

--- a/apps/web/lib/data/thebluealliance/match.ts
+++ b/apps/web/lib/data/thebluealliance/match.ts
@@ -76,12 +76,15 @@ function parseMatchScoreBreakdown(
 }
 
 export async function seedMatches(eventKey: string) {
-	if (!eventKey) {
-		throw new Error("Event key is required");
+	// Validate eventKey to prevent SSRF
+	const eventKeySchema = z.string().regex(/^[a-zA-Z0-9_\-]+$/, "Invalid event key format");
+	const parsedEventKey = eventKeySchema.safeParse(eventKey);
+	if (!parsedEventKey.success) {
+		throw new Error("Invalid event key");
 	}
 
 	const matches = await fetch(
-		`https://www.thebluealliance.com/api/v3/event/${eventKey}/matches`,
+		`https://www.thebluealliance.com/api/v3/event/${parsedEventKey.data}/matches`,
 		{
 			headers: {
 				"X-TBA-Auth-Key": process.env.TBA_API_KEY!,


### PR DESCRIPTION
Potential fix for [https://github.com/yeti-robotics/polar-edge/security/code-scanning/12](https://github.com/yeti-robotics/polar-edge/security/code-scanning/12)

To fix the SSRF vulnerability, we should validate the `eventKey` parameter before using it in the URL. The Blue Alliance event keys follow a specific format (typically alphanumeric, sometimes with underscores or dashes, e.g., "2024miket"). We can use a regular expression to ensure that `eventKey` only contains allowed characters and matches the expected format. If the input does not match, we should throw an error. This validation should be added at the start of the `seedMatches` function in `apps/web/lib/data/thebluealliance/match.ts`. We can use the existing `zod` library (already imported as `z`) to define and enforce this validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
