### PR TITLE
fix(basecamp): floating-point precision in outreach hours display

### DIFF
--- a/apps/basecamp/src/bot/bot.commands.ts
+++ b/apps/basecamp/src/bot/bot.commands.ts
@@ -12,6 +12,7 @@ import { AttendanceService } from "src/attendance/attendance.service";
 import { HandbookService } from "src/handbook/handbook.service";
 import { HandbookQuestionDto } from "src/handbook/handbook-question.dto";
 import { OutreachService } from "src/outreach/outreach.service";
+import { roundToTenth } from "src/utils/math.utils";
 
 // Percentage requirements based on hours to date
 const MEMBER_REQUIRED_PERCENTAGE = 0.75; // 75% of hours to date
@@ -299,7 +300,7 @@ export class BotCommands {
       return interaction.reply("No outreach found for you");
     }
 
-    const hourTotal = Math.round(outreach.reduce((acc, curr) => acc + curr.hours, 0) * 10) / 10;
+    const hourTotal = roundToTenth(outreach.reduce((acc, curr) => acc + curr.hours, 0));
 
     let outreachString = `:snowflake: Outreach for ${nickname} :snowflake:\n\n**Total hours:** ${hourTotal}`;
 

--- a/apps/basecamp/src/outreach/outreach.service.ts
+++ b/apps/basecamp/src/outreach/outreach.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { SheetService } from "src/sheet/sheet.service";
+import { roundToTenth } from "src/utils/math.utils";
 import { z } from "zod";
 
 const OutreachColumnSchema = z.object({
@@ -117,7 +118,7 @@ export class OutreachService {
 
       // Convert to array and sort by total hours (descending)
       const leaderboard = Array.from(userHoursMap.entries())
-        .map(([userName, totalHours]) => ({ userName, totalHours: Math.round(totalHours * 10) / 10 }))
+        .map(([userName, totalHours]) => ({ userName, totalHours: roundToTenth(totalHours) }))
         .sort((a, b) => b.totalHours - a.totalHours)
         .slice(0, limit);
 

--- a/apps/basecamp/src/utils/math.utils.ts
+++ b/apps/basecamp/src/utils/math.utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Rounds a number to the nearest tenth (1 decimal place).
+ * Useful for avoiding floating-point precision issues in display.
+ */
+export function roundToTenth(value: number): number {
+  return Math.round(value * 10) / 10;
+}


### PR DESCRIPTION
Round hourTotal to nearest tenth to prevent values like 24.00000006
from being displayed in the /outreach and /outreach-leaderboard commands.

https://claude.ai/code/session_01SzcTghofVi8MkezKMwB7Ty