### PR TITLE
feat(juice): revamp current management and PDH subsystem page

### DIFF
--- a/apps/juice/astro.config.ts
+++ b/apps/juice/astro.config.ts
@@ -6,9 +6,12 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 import { fileURLToPath } from "node:url";
 
+const isProd = process.env.NODE_ENV === "production";
+
 // https://astro.build/config
 export default defineConfig({
-  adapter: cloudflare(),
+  output: "server",
+  adapter: isProd ? cloudflare() : undefined,
   integrations: [react()],
   vite: {
     plugins: [tailwindcss()],
@@ -16,6 +19,9 @@ export default defineConfig({
       alias: {
         "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
+    },
+    server: {
+      hmr: false,
     },
   },
 });

--- a/apps/juice/package.json
+++ b/apps/juice/package.json
@@ -18,6 +18,8 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "astro": "^6.1.9",
+    "chartjs-plugin-zoom": "^2.2.0",
+    "hammerjs": "^2.0.8",
     "idb": "^8.0.3",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/apps/juice/src/components/battery/AnalysisNav.tsx
+++ b/apps/juice/src/components/battery/AnalysisNav.tsx
@@ -7,6 +7,7 @@ const SECTIONS = [
   { id: "s-current", label: "② Current" },
   { id: "s-power", label: "③ Power" },
   { id: "s-impedance", label: "④ Impedance" },
+  { id: "s-pdh", label: "⑤ PDH Channels" },
 ] as const;
 
 interface AnalysisNavProps {

--- a/apps/juice/src/components/battery/BatteryAnalysis.tsx
+++ b/apps/juice/src/components/battery/BatteryAnalysis.tsx
@@ -4,6 +4,7 @@ import type { MergedData } from "@/services/analysis/types";
 import { AnalysisNav } from "./AnalysisNav";
 import { CurrentSection } from "./CurrentSection";
 import { ImpedanceSection } from "./ImpedanceSection";
+import { PDHSection } from "./PDHSection";
 import { PowerSection } from "./PowerSection";
 import { VoltageSection } from "./VoltageSection";
 
@@ -29,6 +30,7 @@ export function BatteryAnalysis({ data, onNewFiles }: BatteryAnalysisProps) {
       <CurrentSection data={data} />
       <PowerSection data={data} power={power} />
       <ImpedanceSection samples={impedanceSamples} dt={data.dt} />
+      <PDHSection data={data} />
     </div>
   );
 }

--- a/apps/juice/src/components/battery/BatteryApp.tsx
+++ b/apps/juice/src/components/battery/BatteryApp.tsx
@@ -3,7 +3,7 @@ import { generateDemoData } from "@/services/analysis/demo";
 import { mergeData } from "@/services/analysis/merge";
 import { parseDSFile } from "@/services/analysis/parse-voltage";
 import type { MergedData } from "@/services/analysis/types";
-import { parseCANJSON } from "@/services/can/parser";
+import { loadPDHConfig, savePDHConfig, seedDemoConfig } from "@/services/pdh/config";
 import { JuiceNav } from "../JuiceNav";
 import { BatteryAnalysis } from "./BatteryAnalysis";
 import { BatteryLanding } from "./BatteryLanding";
@@ -12,44 +12,34 @@ type Phase = "landing" | "analysis";
 
 export function BatteryApp() {
   const [phase, setPhase] = useState<Phase>("landing");
-  const [dsFile, setDsFile] = useState<File | null>(null);
-  const [canFile, setCanFile] = useState<File | null>(null);
+  const [logFile, setLogFile] = useState<File | null>(null);
   const [mergedData, setMergedData] = useState<MergedData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleAnalyze = async () => {
-    if (!dsFile) return;
+    if (!logFile) return;
     setLoading(true);
     setError(null);
 
     try {
-      const dsBuffer = await dsFile.arrayBuffer();
-      const result = parseDSFile(dsFile.name, dsBuffer);
+      const buffer = await logFile.arrayBuffer();
+      const result = parseDSFile(logFile.name, buffer);
 
       if (!result || result.voltage.length < 10) {
         setError(
-          "Could not parse DS log. Make sure it is a .dslog binary or CSV with a voltage column (values 6–15 V)."
+          "Could not parse the log file. Supported formats: .dslog binary, .wpilog binary, or CSV with a voltage column (values 6–15 V)."
         );
         setLoading(false);
         return;
       }
 
-      // Use current from the DS log's PDP channels by default.
-      // If a CAN JSON file is provided, it overrides the current source.
-      let currentData = result.current.length > 0 ? result.current : null;
-
-      if (canFile) {
-        const canText = await canFile.text();
-        const canParsed = parseCANJSON(canText);
-        if (canParsed) currentData = canParsed;
-      }
-
+      const currentData = result.current.length > 0 ? result.current : null;
       const merged = mergeData(result.voltage, currentData, result.channels);
       setMergedData(merged);
       setPhase("analysis");
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to analyze files");
+      setError(e instanceof Error ? e.message : "Failed to analyze file");
     } finally {
       setLoading(false);
     }
@@ -58,11 +48,16 @@ export function BatteryApp() {
   const handleDemo = () => {
     setLoading(true);
     setTimeout(() => {
-      const { dsData, canData } = generateDemoData();
-      const merged = mergeData(dsData, canData);
+      const { dsData, canData, channels } = generateDemoData();
+      const merged = mergeData(dsData, canData, channels);
+
+      // Seed PDH config with realistic FRC labels if the user hasn't set any yet
+      const cfg = loadPDHConfig();
+      const hasLabels = cfg.channels.some((ch) => ch.label !== "");
+      if (!hasLabels) savePDHConfig(seedDemoConfig());
+
       setMergedData(merged);
-      setDsFile(null);
-      setCanFile(null);
+      setLogFile(null);
       setPhase("analysis");
       setLoading(false);
     }, 50);
@@ -81,10 +76,8 @@ export function BatteryApp() {
     <>
       <JuiceNav active="analyzer" />
       <BatteryLanding
-        dsFile={dsFile}
-        canFile={canFile}
-        onDsFileSelect={setDsFile}
-        onCanFileSelect={setCanFile}
+        logFile={logFile}
+        onLogFileSelect={setLogFile}
         onAnalyze={handleAnalyze}
         onDemo={handleDemo}
         loading={loading}

--- a/apps/juice/src/components/battery/BatteryLanding.tsx
+++ b/apps/juice/src/components/battery/BatteryLanding.tsx
@@ -2,20 +2,16 @@ import { Button } from "@repo/ui/components/button";
 import { FileUploadCard } from "./FileUploadCard";
 
 interface BatteryLandingProps {
-  dsFile: File | null;
-  canFile: File | null;
-  onDsFileSelect: (file: File) => void;
-  onCanFileSelect: (file: File) => void;
+  logFile: File | null;
+  onLogFileSelect: (file: File) => void;
   onAnalyze: () => void;
   onDemo: () => void;
   loading: boolean;
 }
 
 export function BatteryLanding({
-  dsFile,
-  canFile,
-  onDsFileSelect,
-  onCanFileSelect,
+  logFile,
+  onLogFileSelect,
   onAnalyze,
   onDemo,
   loading,
@@ -31,60 +27,39 @@ export function BatteryLanding({
       </h1>
 
       <p className="mb-12 max-w-lg text-center text-sm leading-relaxed text-muted-foreground">
-        Upload your <strong className="text-foreground">DS Log</strong> to analyze battery voltage
-        and current from PDP/PDH channels. Optionally add a{" "}
-        <strong className="text-foreground">CAN JSON</strong> to override the current source with
-        per-device CAN bus data.
+        Upload your{" "}
+        <strong className="text-foreground">DS Log</strong> to analyze battery voltage, current
+        demand, and per-channel PDH power distribution.
       </p>
 
-      <div className="mb-7 grid w-full max-w-[700px] grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="mb-7 mx-auto w-full max-w-xl">
         <FileUploadCard
           label="Required"
-          title="DS Log"
+          title="DS Log File"
           description={
             <>
               <code className="rounded bg-primary/10 px-1 py-0.5 font-mono text-[11px] text-primary">
                 .dslog
               </code>{" "}
-              binary or{" "}
-              <code className="rounded bg-primary/10 px-1 py-0.5 font-mono text-[11px] text-primary">
-                .csv
-              </code>{" "}
-              export.
-              <br />
-              Provides voltage and PDP/PDH current at ~50 Hz.
+              binary — provides voltage, current, and PDH channel data.
             </>
           }
           icon="📋"
           accept="*"
-          file={dsFile}
+          file={logFile}
           variant="required"
-          onFileSelect={onDsFileSelect}
-        />
-        <FileUploadCard
-          label="Optional"
-          title="CAN JSON"
-          description={
-            <>
-              Overrides PDP current with per-device CAN bus data.
-              <br />
-              JSON array with{" "}
-              <code className="rounded bg-amber-500/10 px-1 py-0.5 font-mono text-[11px] text-amber-500">
-                time
-              </code>{" "}
-              and current fields per device.
-            </>
-          }
-          icon="🔌"
-          accept=".json,.txt,.csv,*"
-          file={canFile}
-          variant="optional"
-          onFileSelect={onCanFileSelect}
+          onFileSelect={(f) => {
+            if (!f.name.toLowerCase().endsWith(".dslog")) {
+              alert("Please select a .dslog file.");
+              return;
+            }
+            onLogFileSelect(f);
+          }}
         />
       </div>
 
       <div className="flex flex-col items-center gap-3">
-        <Button onClick={onAnalyze} disabled={!dsFile || loading} className="px-10">
+        <Button onClick={onAnalyze} disabled={!logFile || loading} className="px-10">
           {loading ? "Analyzing..." : "⚡ Analyze"}
         </Button>
         <Button
@@ -97,26 +72,19 @@ export function BatteryLanding({
         </Button>
       </div>
 
-      <div className="mt-9 grid w-full max-w-[700px] grid-cols-1 gap-3 sm:grid-cols-3">
+      <div className="mt-9 grid w-full max-w-[500px] grid-cols-1 gap-3 sm:grid-cols-2">
         <HintCard title="DS Log files">
-          The <code className="text-primary">.dslog</code> binary contains voltage, PDP/PDH channel
+          The{" "}
+          <code className="text-primary">.dslog</code> binary contains voltage, PDP/PDH channel
           currents, trip time, packet loss, CAN utilization, and more — all parsed natively.
-        </HintCard>
-        <HintCard title="CAN JSON override">
-          Optionally provide a CAN JSON to replace PDP current with per-device CAN bus readings —
-          useful for more granular current profiling via WPILib or AdvantageScope.
         </HintCard>
         <HintCard title="What gets analyzed?">
           Voltage trends, current demand, instantaneous power{" "}
           <span className="inline-flex items-baseline gap-0.5 rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-foreground">
             <i>P</i> = <i>V</i> × <i>I</i>
           </span>
-          , and battery impedance{" "}
-          <span className="inline-flex items-baseline gap-0.5 rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-foreground">
-            <i>R</i> = (<i>V</i>
-            <sub>oc</sub> − <i>V</i>) / <i>I</i>
-          </span>{" "}
-          — all with rolling windows, regression lines, and CSV export.
+          , battery impedance, and a per-subsystem PDH breakdown with rolling windows and CSV
+          export.
         </HintCard>
       </div>
     </div>

--- a/apps/juice/src/components/battery/ChartCard.tsx
+++ b/apps/juice/src/components/battery/ChartCard.tsx
@@ -15,6 +15,7 @@ import {
   ScatterController,
   Tooltip,
 } from "chart.js";
+import zoomPlugin from "chartjs-plugin-zoom";
 import { useMemo, useRef } from "react";
 import { Chart } from "react-chartjs-2";
 
@@ -29,7 +30,8 @@ ChartJS.register(
   BarController,
   ScatterController,
   Tooltip,
-  Filler
+  Filler,
+  zoomPlugin
 );
 
 export interface ThresholdLine {
@@ -182,10 +184,22 @@ export function ChartCard({
 
       {/* Chart */}
       <div className="rounded-lg border border-border bg-card p-4">
-        <h3 className="font-mono text-[9px] uppercase tracking-widest text-muted-foreground">
-          {title}
-        </h3>
-        <p className="mb-3 text-[11px] text-muted-foreground">{subtitle}</p>
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <h3 className="font-mono text-[9px] uppercase tracking-widest text-muted-foreground">
+              {title}
+            </h3>
+            <p className="text-[11px] text-muted-foreground">{subtitle}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => (chartRef.current as ChartJS | null)?.resetZoom()}
+            className="flex-shrink-0 rounded border border-border px-2 py-0.5 font-mono text-[9px] text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
+            title="Reset zoom"
+          >
+            Reset zoom
+          </button>
+        </div>
         <div style={{ height }}>
           <Chart
             ref={chartRef}
@@ -195,12 +209,31 @@ export function ChartCard({
               responsive: true,
               maintainAspectRatio: false,
               animation: false,
-              plugins: { legend: { display: false } },
+              plugins: {
+                legend: { display: false },
+                zoom: {
+                  limits: {
+                    x: { min: "original", max: "original", minRange: 12 },
+                  },
+                  zoom: {
+                    wheel: { enabled: true },
+                    drag: { enabled: true, backgroundColor: "oklch(0.7366 0.1138 232.04 / 0.1)", borderColor: "oklch(0.7366 0.1138 232.04 / 0.4)", borderWidth: 1 },
+                    mode: "x",
+                  },
+                  pan: {
+                    enabled: true,
+                    mode: "x",
+                  },
+                },
+              },
               ...options,
             }}
             plugins={plugins}
           />
         </div>
+        <p className="mt-2 font-mono text-[9px] text-muted-foreground/50">
+          Scroll to zoom · Drag to select range · Shift+drag to pan · Reset zoom to fit all
+        </p>
       </div>
 
       {onDownload && (

--- a/apps/juice/src/components/battery/CurrentSection.tsx
+++ b/apps/juice/src/components/battery/CurrentSection.tsx
@@ -8,33 +8,12 @@ import type { MergedData } from "@/services/analysis/types";
 import { ChartCard, type SeriesToggle } from "./ChartCard";
 import { StatCard } from "./StatCard";
 
-// YETI dark mode chart palette
 const COLORS = {
-  raw: "oklch(0.7366 0.1138 232.04 / 0.5)", // yeti-400 (semi-transparent)
-  rawSolid: "oklch(0.7366 0.1138 232.04)", // yeti-400
-  peaks: "oklch(0.645 0.246 16.439 / 0.7)", // chart-5 red
-  reg: "oklch(0.627 0.265 303.9)", // chart-4 magenta
+  raw: "oklch(0.7366 0.1138 232.04 / 0.5)",
+  rawSolid: "oklch(0.7366 0.1138 232.04)",
+  peaks: "oklch(0.645 0.246 16.439 / 0.7)",
+  reg: "oklch(0.627 0.265 303.9)",
 };
-
-// Distinct colors for per-channel lines
-const CHANNEL_COLORS = [
-  "oklch(0.696 0.17 162.48)", // chart-2 teal
-  "oklch(0.769 0.188 70.08)", // chart-3 yellow
-  "oklch(0.627 0.265 303.9)", // chart-4 magenta
-  "oklch(0.645 0.246 16.439)", // chart-5 red
-  "oklch(0.488 0.243 264.376)", // chart-1 purple
-  "oklch(0.7366 0.1138 232.04)", // yeti-400
-  "oklch(0.8135 0.0831 232.31)", // yeti-300
-  "oklch(0.5538 0.1209 240.68)", // yeti-600
-  "oklch(0.768 0.165 54)", // warning
-  "oklch(0.704 0.191 22.216)", // destructive
-  "oklch(0.6 0.118 184.704)", // light chart-2
-  "oklch(0.828 0.189 84.429)", // light chart-4
-  "oklch(0.646 0.222 41.116)", // light chart-1
-  "oklch(0.398 0.07 227.392)", // light chart-3
-  "oklch(0.769 0.188 70.08)", // chart-3
-  "oklch(0.4747 0.1025 241.12)", // yeti-700
-];
 
 const TICK_STYLE = {
   color: "oklch(0.552 0.016 285.938)",
@@ -58,18 +37,6 @@ export function CurrentSection({ data }: CurrentSectionProps) {
     peaks: true,
     reg: true,
   });
-
-  const channelNames = useMemo(
-    () =>
-      Object.keys(data.channels).sort((a, b) => {
-        const numA = Number.parseInt(a.replace(/\D/g, ""), 10);
-        const numB = Number.parseInt(b.replace(/\D/g, ""), 10);
-        return numA - numB;
-      }),
-    [data.channels]
-  );
-
-  const [enabledChannels, setEnabledChannels] = useState<Set<string>>(() => new Set<string>());
 
   const safeCurr = useMemo(
     () => data.currents.map((c) => (Number.isNaN(c) ? 0 : Math.max(0, c))),
@@ -158,31 +125,8 @@ export function CurrentSection({ data }: CurrentSectionProps) {
       },
     ];
 
-    // Add per-channel lines for enabled channels (with rolling window applied)
-    for (const chName of channelNames) {
-      if (!enabledChannels.has(chName)) continue;
-      const chData = data.channels[chName];
-      if (!chData) continue;
-      const smoothed = rollingMean(new Float64Array(chData), window);
-      const chVals: number[] = [];
-      for (let i = 0; i < chData.length; i += step) {
-        chVals.push(Number(smoothed[i]?.toFixed(2)));
-      }
-      const colorIdx = channelNames.indexOf(chName) % CHANNEL_COLORS.length;
-      datasets.push({
-        type: "line" as const,
-        label: chName,
-        data: chVals,
-        borderColor: CHANNEL_COLORS[colorIdx] ?? CHANNEL_COLORS[0],
-        borderWidth: 1.2,
-        pointRadius: 0,
-        fill: false,
-        tension: 0.04,
-      });
-    }
-
     return { labels, datasets };
-  }, [data, safeCurr, rollC, peakIdx, reg, channelNames, enabledChannels, window]);
+  }, [data, safeCurr, rollC, peakIdx, reg, window]);
 
   const chartOptions = useMemo<ChartOptions>(
     () => ({
@@ -207,30 +151,15 @@ export function CurrentSection({ data }: CurrentSectionProps) {
     []
   );
 
-  // Build toggles: base series + channel toggles handled separately
   const seriesToggle: SeriesToggle[] = [
     { key: "raw", label: "Total current", color: COLORS.rawSolid, active: toggles.raw },
     { key: "roll", label: "Rolling mean", color: COLORS.rawSolid, active: toggles.roll },
-    {
-      key: "peaks",
-      label: "Peak scatter",
-      color: "oklch(0.645 0.246 16.439)",
-      active: toggles.peaks,
-    },
+    { key: "peaks", label: "Peak scatter", color: "oklch(0.645 0.246 16.439)", active: toggles.peaks },
     { key: "reg", label: "Regression (peaks)", color: COLORS.reg, active: toggles.reg },
   ];
 
   const handleToggle = useCallback((key: string) => {
     setToggles((prev) => ({ ...prev, [key]: !prev[key as keyof typeof prev] }));
-  }, []);
-
-  const toggleChannel = useCallback((chName: string) => {
-    setEnabledChannels((prev) => {
-      const next = new Set(prev);
-      if (next.has(chName)) next.delete(chName);
-      else next.add(chName);
-      return next;
-    });
   }, []);
 
   const f1 = (v: number) => (Number.isNaN(v) ? "—" : v.toFixed(1));
@@ -290,35 +219,6 @@ export function CurrentSection({ data }: CurrentSectionProps) {
             color={stats.samplesAbove120 === 0 ? "green" : "red"}
           />
         </div>
-
-        {/* Per-channel filter */}
-        {channelNames.length > 0 && (
-          <div className="mb-3 flex flex-wrap items-center gap-2 rounded-md border border-border bg-card/50 p-3">
-            <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-              Channels
-            </span>
-            {channelNames.map((ch) => {
-              const active = enabledChannels.has(ch);
-              const colorIdx = channelNames.indexOf(ch) % CHANNEL_COLORS.length;
-              return (
-                <button
-                  key={ch}
-                  type="button"
-                  onClick={() => toggleChannel(ch)}
-                  className="rounded border px-2 py-0.5 font-mono text-[10px] transition-colors"
-                  style={{
-                    backgroundColor: active ? CHANNEL_COLORS[colorIdx] : "transparent",
-                    color: active ? "var(--background)" : "var(--muted-foreground)",
-                    borderColor: active ? CHANNEL_COLORS[colorIdx] : "var(--border)",
-                    fontWeight: active ? 500 : 400,
-                  }}
-                >
-                  {ch}
-                </button>
-              );
-            })}
-          </div>
-        )}
 
         <ChartCard
           title="Current over time"

--- a/apps/juice/src/components/battery/FileUploadCard.tsx
+++ b/apps/juice/src/components/battery/FileUploadCard.tsx
@@ -49,7 +49,7 @@ export function FileUploadCard({
         const f = e.dataTransfer.files[0];
         if (f) onFileSelect(f);
       }}
-      className={`flex cursor-pointer flex-col items-center gap-2 rounded-lg border bg-card/50 p-6 text-center transition-colors ${borderClass}`}
+      className={`flex w-full cursor-pointer flex-col items-center gap-3 rounded-lg border bg-card/50 px-10 py-10 text-center transition-colors ${borderClass}`}
     >
       <span className="text-3xl">{icon}</span>
       <span

--- a/apps/juice/src/components/battery/PDHSection.tsx
+++ b/apps/juice/src/components/battery/PDHSection.tsx
@@ -1,0 +1,756 @@
+import type { ChartData, ChartOptions } from "chart.js";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  exportPDHConfig,
+  getChannelBreaker,
+  importPDHConfig,
+  loadPDHConfig,
+  PDH_CHANNEL_COUNT,
+  PDH_COLORS,
+  savePDHConfig,
+  type PDHConfig,
+  type SubsystemConfig,
+} from "@/services/pdh/config";
+import type { MergedData } from "@/services/analysis/types";
+import { detectPhases, type PhaseSegment } from "@/services/analysis/phases";
+import { rollingMean } from "@/services/analysis/rolling";
+import { ChartCard } from "./ChartCard";
+
+interface PDHSectionProps {
+  data: MergedData;
+}
+
+const TICK_STYLE = {
+  color: "oklch(0.552 0.016 285.938)",
+  font: { family: "ui-monospace, monospace", size: 10 as const },
+};
+
+export function PDHSection({ data }: PDHSectionProps) {
+  const [config, setConfig] = useState<PDHConfig>(() => loadPDHConfig());
+
+  useEffect(() => {
+    const onStorage = () => setConfig(loadPDHConfig());
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const persist = useCallback((next: PDHConfig) => {
+    setConfig(next);
+    savePDHConfig(next);
+  }, []);
+
+  // ── Subsystem management ──────────────────────────────────────
+
+  const addSubsystem = useCallback(() => {
+    setConfig((prev) => {
+      const idx = prev.subsystems.length % PDH_COLORS.length;
+      const next: PDHConfig = {
+        ...prev,
+        subsystems: [
+          ...prev.subsystems,
+          { name: `Subsystem ${prev.subsystems.length + 1}`, color: PDH_COLORS[idx] ?? "#3b82f6", weight: 0 },
+        ],
+      };
+      savePDHConfig(next);
+      return next;
+    });
+  }, []);
+
+  const renameSubsystem = useCallback(
+    (oldName: string, newName: string) => {
+      persist({
+        ...config,
+        subsystems: config.subsystems.map((s) => (s.name === oldName ? { ...s, name: newName } : s)),
+        channels: config.channels.map((ch) =>
+          ch.subsystem === oldName ? { ...ch, subsystem: newName } : ch
+        ),
+      });
+    },
+    [config, persist]
+  );
+
+  const updateSubsystemColor = useCallback(
+    (name: string, color: string) => {
+      persist({
+        ...config,
+        subsystems: config.subsystems.map((s) => (s.name === name ? { ...s, color } : s)),
+      });
+    },
+    [config, persist]
+  );
+
+  const deleteSubsystem = useCallback(
+    (name: string) => {
+      persist({
+        ...config,
+        subsystems: config.subsystems.filter((s) => s.name !== name),
+        channels: config.channels.map((ch) =>
+          ch.subsystem === name ? { ...ch, subsystem: "" } : ch
+        ),
+      });
+    },
+    [config, persist]
+  );
+
+  const setChannelLabel = useCallback(
+    (ch: number, label: string) => {
+      const channels = [...config.channels];
+      channels[ch] = { ...channels[ch]!, label };
+      persist({ ...config, channels });
+    },
+    [config, persist]
+  );
+
+  // ── Drag and drop ─────────────────────────────────────────────
+
+  const [pdhWindow, setPdhWindow] = useState(5);
+  const [showPhases, setShowPhases] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImport = useCallback(async (file: File) => {
+    try {
+      const imported = await importPDHConfig(file);
+      persist(imported);
+      setImportError(null);
+    } catch (e) {
+      setImportError(e instanceof Error ? e.message : "Import failed.");
+    }
+  }, [persist]);
+
+  const [dragging, setDragging] = useState<number | null>(null);
+  const [dragOver, setDragOver] = useState<string | null>(null);
+  const dragCounters = useRef<Record<string, number>>({});
+
+  const handleDragStart = useCallback((ch: number) => setDragging(ch), []);
+  const handleDragEnd = useCallback(() => { setDragging(null); setDragOver(null); }, []);
+
+  const handleDragEnter = useCallback((zone: string) => {
+    dragCounters.current[zone] = (dragCounters.current[zone] ?? 0) + 1;
+    setDragOver(zone);
+  }, []);
+
+  const handleDragLeave = useCallback((zone: string) => {
+    dragCounters.current[zone] = (dragCounters.current[zone] ?? 1) - 1;
+    if ((dragCounters.current[zone] ?? 0) <= 0) {
+      dragCounters.current[zone] = 0;
+      setDragOver((prev) => (prev === zone ? null : prev));
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (zone: string) => {
+      if (dragging === null) return;
+      const channels = [...config.channels];
+      channels[dragging] = { ...channels[dragging]!, subsystem: zone === "__unassigned" ? "" : zone };
+      persist({ ...config, channels });
+      dragCounters.current = {};
+      setDragOver(null);
+    },
+    [dragging, config, persist]
+  );
+
+  // ── Chart data ────────────────────────────────────────────────
+
+  const hasChannelData = useMemo(() => Object.keys(data.channels).length > 0, [data.channels]);
+
+  const channelMeans = useMemo(() => {
+    const out: Record<number, number> = {};
+    for (let ch = 0; ch < PDH_CHANNEL_COUNT; ch++) {
+      const arr = data.channels[`CH ${ch}`];
+      if (!arr || arr.length === 0) { out[ch] = 0; continue; }
+      const tail = arr.slice(-Math.min(50, arr.length));
+      out[ch] = tail.reduce((s, v) => s + v, 0) / tail.length;
+    }
+    return out;
+  }, [data.channels]);
+
+  const channelPeaks = useMemo(() => {
+    const out: Record<number, number> = {};
+    for (let ch = 0; ch < PDH_CHANNEL_COUNT; ch++) {
+      const arr = data.channels[`CH ${ch}`];
+      out[ch] = arr && arr.length > 0 ? Math.max(...arr) : 0;
+    }
+    return out;
+  }, [data.channels]);
+
+  const safeCurr = useMemo(
+    () => data.currents.map((c) => (Number.isNaN(c) ? 0 : Math.max(0, c))),
+    [data.currents]
+  );
+
+  const subsystemStats = useMemo(() => {
+    const stats: Record<string, { mean: number; peak: number }> = {};
+    for (const sub of config.subsystems) {
+      if (!hasChannelData) {
+        if (sub.weight > 0) {
+          const weighted = safeCurr.map((c) => c * (sub.weight / 100));
+          const mean = weighted.reduce((s, v) => s + v, 0) / (weighted.length || 1);
+          stats[sub.name] = { mean, peak: weighted.length > 0 ? Math.max(...weighted) : 0 };
+        } else {
+          stats[sub.name] = { mean: 0, peak: 0 };
+        }
+        continue;
+      }
+      const chIndices = config.channels
+        .map((ch, idx) => (ch.subsystem === sub.name ? idx : -1))
+        .filter((idx) => idx !== -1);
+      if (chIndices.length === 0) { stats[sub.name] = { mean: 0, peak: 0 }; continue; }
+      const totals = Array.from({ length: data.times.length }, (_, i) =>
+        chIndices.reduce((sum, ch) => sum + (data.channels[`CH ${ch}`]?.[i] ?? 0), 0)
+      );
+      const mean = totals.reduce((s, v) => s + v, 0) / (totals.length || 1);
+      stats[sub.name] = { mean, peak: totals.length > 0 ? Math.max(...totals) : 0 };
+    }
+    return stats;
+  }, [config, data, hasChannelData, safeCurr]);
+
+  const chartData = useMemo<ChartData<"line">>(() => {
+    const step = Math.max(1, Math.floor(data.times.length / 600));
+    const labels = data.times.filter((_, i) => i % step === 0).map((t) => +t.toFixed(2));
+    const datasets: ChartData<"line">["datasets"] = [];
+
+    if (config.subsystems.length === 0) {
+      const smoothed = Array.from(rollingMean(new Float64Array(safeCurr), pdhWindow));
+      datasets.push({
+        label: "Total current",
+        data: smoothed.filter((_, i) => i % step === 0).map((v) => +v.toFixed(2)),
+        borderColor: "oklch(0.7366 0.1138 232.04)",
+        fill: false,
+        borderWidth: 1.5,
+        pointRadius: 0,
+        tension: 0.1,
+      });
+      return { labels, datasets };
+    }
+
+    for (const sub of config.subsystems) {
+      let subCurrents: number[];
+
+      if (hasChannelData) {
+        const chIndices = config.channels
+          .map((ch, idx) => (ch.subsystem === sub.name ? idx : -1))
+          .filter((idx) => idx !== -1);
+        subCurrents = Array.from({ length: data.times.length }, (_, i) =>
+          chIndices.reduce((sum, ch) => sum + (data.channels[`CH ${ch}`]?.[i] ?? 0), 0)
+        );
+      } else {
+        if (sub.weight <= 0) continue;
+        subCurrents = safeCurr.map((c) => c * (sub.weight / 100));
+      }
+
+      const smoothed = Array.from(rollingMean(new Float64Array(subCurrents), pdhWindow));
+      datasets.push({
+        label: sub.name,
+        data: smoothed.filter((_, i) => i % step === 0).map((v) => +v.toFixed(2)),
+        fill: false,
+        borderColor: sub.color,
+        borderWidth: 1.5,
+        pointRadius: 0,
+        tension: 0.1,
+      });
+    }
+
+    return { labels, datasets };
+  }, [data, config, hasChannelData, safeCurr, pdhWindow]);
+
+  const chartOptions = useMemo<ChartOptions>(
+    () => ({
+      scales: {
+        x: { ticks: { ...TICK_STYLE, maxTicksLimit: 12 }, grid: { color: "oklch(1 0 0 / 0.04)" } },
+        y: {
+          min: 0,
+          ticks: TICK_STYLE,
+          grid: { color: "oklch(1 0 0 / 0.04)" },
+          title: { display: true, text: "A", color: TICK_STYLE.color, font: { size: 10, family: "ui-monospace, monospace" } },
+        },
+      },
+    }),
+    []
+  );
+
+  const phases = useMemo(
+    () => (showPhases ? detectPhases(data, config) : []),
+    [data, config, showPhases]
+  );
+
+  const channelsByZone = (zoneName: string) =>
+    Array.from({ length: PDH_CHANNEL_COUNT }, (_, i) => i).filter((ch) => {
+      const sub = config.channels[ch]?.subsystem ?? "";
+      return zoneName === "__unassigned" ? sub === "" : sub === zoneName;
+    });
+
+  return (
+    <section className="scroll-mt-14 border-b border-border px-7 py-10" id="s-pdh">
+      <div className="mx-auto max-w-[1300px]">
+
+        {/* Header */}
+        <div className="mb-6 flex flex-wrap items-center gap-3">
+          <span className="rounded border border-primary/25 bg-primary/10 px-2.5 py-0.5 font-mono text-[10px] font-semibold tracking-wider text-primary">
+            05
+          </span>
+          <h2 className="text-xl font-medium">PDH Channels</h2>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShowPhases((v) => !v)}
+              className={`rounded border px-3 py-1 font-mono text-[10px] transition-colors ${
+                showPhases
+                  ? "border-primary/50 bg-primary/10 text-primary"
+                  : "border-border bg-card text-muted-foreground hover:border-primary/50 hover:text-primary"
+              }`}
+            >
+              {showPhases ? "◉ Phase detection on" : "○ Phase detection"}
+            </button>
+            <button
+              type="button"
+              onClick={() => exportPDHConfig(config)}
+              className="rounded border border-border bg-card px-3 py-1 font-mono text-[10px] text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
+            >
+              Export config
+            </button>
+            <button
+              type="button"
+              onClick={() => importInputRef.current?.click()}
+              className="rounded border border-border bg-card px-3 py-1 font-mono text-[10px] text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
+            >
+              Import config
+            </button>
+            <input
+              ref={importInputRef}
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) handleImport(f);
+                e.target.value = "";
+              }}
+            />
+          </div>
+        </div>
+        {importError && (
+          <p className="mb-4 rounded border border-destructive/30 bg-destructive/5 px-3 py-2 font-mono text-[11px] text-destructive">
+            {importError}
+          </p>
+        )}
+
+        {/* Top row: subsystem list LEFT + chart RIGHT */}
+        <div className="mb-6 flex gap-4">
+
+          {/* Left: subsystem list */}
+          <div className="flex w-52 flex-shrink-0 flex-col gap-2">
+            <span className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground">
+              Subsystems
+            </span>
+
+            {config.subsystems.map((sub) => {
+              const chNums = channelsByZone(sub.name);
+              return (
+                <SubsystemRow
+                  key={sub.name}
+                  sub={sub}
+                  channels={chNums.map((ch) => ({ ch, label: config.channels[ch]?.label ?? "" }))}
+                  stats={subsystemStats[sub.name]}
+                  onRename={(newName) => renameSubsystem(sub.name, newName)}
+                  onColorChange={(color) => updateSubsystemColor(sub.name, color)}
+                  onDelete={() => deleteSubsystem(sub.name)}
+                />
+              );
+            })}
+
+            {config.subsystems.length === 0 && (
+              <p className="text-[11px] text-muted-foreground">No subsystems yet.</p>
+            )}
+
+            <button
+              type="button"
+              onClick={addSubsystem}
+              className="mt-1 rounded border border-dashed border-border py-1.5 font-mono text-[10px] text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+            >
+              + Add subsystem
+            </button>
+          </div>
+
+          {/* Right: chart */}
+          <div className="min-w-0 flex-1">
+            <ChartCard
+              title="Current draw by subsystem"
+              subtitle={
+                hasChannelData
+                  ? "Measured per-channel current grouped by subsystem."
+                  : config.subsystems.length > 0
+                    ? "Estimated — total current scaled by subsystem weight %."
+                    : "Assign channels to subsystems below to see a breakdown."
+              }
+              data={chartData}
+              options={chartOptions}
+              height={260}
+              windowValue={pdhWindow}
+              windowLabel={data.dt > 0 ? `${(pdhWindow * data.dt).toFixed(2)}s` : `${pdhWindow}×`}
+              onWindowChange={setPdhWindow}
+            />
+            {showPhases && config.subsystems.length > 0 && (
+              <div className="mt-4 rounded-lg border border-border bg-card p-4">
+                <h4 className="mb-3 font-mono text-[9px] uppercase tracking-wider text-muted-foreground">
+                  Phase detection
+                </h4>
+                {phases.length === 0 ? (
+                  <p className="font-mono text-[11px] text-muted-foreground/60">
+                    No active phases detected. Assign channels to subsystems and load a file with PDH current data.
+                  </p>
+                ) : (
+                  <PhaseTimeline
+                    phases={phases}
+                    subsystems={config.subsystems}
+                    startT={data.times[0] ?? 0}
+                    endT={data.times[data.times.length - 1] ?? 0}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Bottom: drag-and-drop channel zones */}
+        <div className="space-y-3">
+          <span className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground">
+            Channels — drag to assign
+          </span>
+
+          <DropZone
+            name="__unassigned"
+            label="Unassigned"
+            color="#6b7280"
+            channels={channelsByZone("__unassigned")}
+            config={config}
+            hasChannelData={hasChannelData}
+            channelMeans={channelMeans}
+            channelPeaks={channelPeaks}
+            isDragOver={dragOver === "__unassigned"}
+            onDragEnter={() => handleDragEnter("__unassigned")}
+            onDragLeave={() => handleDragLeave("__unassigned")}
+            onDrop={() => handleDrop("__unassigned")}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onLabelChange={setChannelLabel}
+          />
+
+          {config.subsystems.map((sub) => (
+            <DropZone
+              key={sub.name}
+              name={sub.name}
+              label={sub.name}
+              color={sub.color}
+              channels={channelsByZone(sub.name)}
+              config={config}
+              hasChannelData={hasChannelData}
+              channelMeans={channelMeans}
+              channelPeaks={channelPeaks}
+              isDragOver={dragOver === sub.name}
+              onDragEnter={() => handleDragEnter(sub.name)}
+              onDragLeave={() => handleDragLeave(sub.name)}
+              onDrop={() => handleDrop(sub.name)}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              onLabelChange={setChannelLabel}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── PhaseTimeline ─────────────────────────────────────────────────────────────
+
+interface PhaseTimelineProps {
+  phases: PhaseSegment[];
+  subsystems: SubsystemConfig[];
+  startT: number;
+  endT: number;
+}
+
+function PhaseTimeline({ phases, subsystems, startT, endT }: PhaseTimelineProps) {
+  const duration = endT - startT;
+  if (duration <= 0) return null;
+
+  return (
+    <div className="space-y-1.5">
+      {subsystems.map((sub) => {
+        const segs = phases.filter((p) => p.subsystem === sub.name);
+        return (
+          <div key={sub.name} className="flex items-center gap-2">
+            <span className="w-24 flex-shrink-0 truncate text-right font-mono text-[9px] text-muted-foreground">
+              {sub.name}
+            </span>
+            <div className="relative h-4 flex-1 overflow-hidden rounded border border-border bg-background">
+              {segs.map((seg, i) => {
+                const left = ((seg.startT - startT) / duration) * 100;
+                const width = ((seg.endT - seg.startT) / duration) * 100;
+                return (
+                  <div
+                    // biome-ignore lint/suspicious/noArrayIndexKey: segments have no stable id
+                    key={i}
+                    className="absolute top-0 h-full"
+                    style={{ left: `${left}%`, width: `${Math.max(width, 0.2)}%`, backgroundColor: sub.color + "cc" }}
+                    title={`${seg.startT.toFixed(2)}s – ${seg.endT.toFixed(2)}s`}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+      {/* Time axis */}
+      <div className="flex items-center gap-2">
+        <span className="w-24 flex-shrink-0" />
+        <div className="relative h-3 flex-1 font-mono text-[9px] text-muted-foreground/40">
+          <span className="absolute left-0">{startT.toFixed(0)}s</span>
+          <span className="absolute left-1/2 -translate-x-1/2">{((startT + endT) / 2).toFixed(0)}s</span>
+          <span className="absolute right-0">{endT.toFixed(0)}s</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── SubsystemRow ──────────────────────────────────────────────────────────────
+
+interface SubsystemRowProps {
+  sub: SubsystemConfig;
+  channels: { ch: number; label: string }[];
+  stats?: { mean: number; peak: number };
+  onRename: (name: string) => void;
+  onColorChange: (color: string) => void;
+  onDelete: () => void;
+}
+
+function SubsystemRow({ sub, channels, stats, onRename, onColorChange, onDelete }: SubsystemRowProps) {
+  const colorRef = useRef<HTMLInputElement>(null);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(sub.name);
+  const [open, setOpen] = useState(false);
+
+  const commit = () => {
+    setEditing(false);
+    if (draft.trim() && draft.trim() !== sub.name) onRename(draft.trim());
+    else setDraft(sub.name);
+  };
+
+  return (
+    <div className="rounded-md border border-border bg-card">
+      {/* Header row */}
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        {/* Color swatch */}
+        <button
+          type="button"
+          onClick={() => colorRef.current?.click()}
+          className="h-3 w-3 flex-shrink-0 cursor-pointer rounded-full ring-1 ring-border/50 transition-transform hover:scale-125"
+          style={{ backgroundColor: sub.color }}
+          title="Change color"
+        />
+        <input type="color" ref={colorRef} value={sub.color} onChange={(e) => onColorChange(e.target.value)} className="sr-only" />
+
+        {/* Name — click to rename */}
+        {editing ? (
+          <input
+            autoFocus
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commit();
+              if (e.key === "Escape") { setEditing(false); setDraft(sub.name); }
+            }}
+            className="min-w-0 flex-1 rounded border border-primary/50 bg-background px-1 py-0.5 font-mono text-[11px] text-foreground focus:outline-none"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => { setDraft(sub.name); setEditing(true); }}
+            className="min-w-0 flex-1 truncate text-left font-mono text-[11px] text-foreground hover:text-primary"
+            title="Click to rename"
+          >
+            {sub.name}
+          </button>
+        )}
+
+        {/* Expand toggle */}
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex-shrink-0 font-mono text-[10px] text-muted-foreground hover:text-foreground"
+          title={open ? "Collapse" : "Show channels"}
+        >
+          {channels.length}ch {open ? "▲" : "▼"}
+        </button>
+
+        <button
+          type="button"
+          onClick={onDelete}
+          className="flex-shrink-0 rounded border border-transparent px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground/50 transition-colors hover:border-destructive/40 hover:bg-destructive/5 hover:text-destructive"
+          title="Remove subsystem and return all channels to unassigned"
+        >
+          Disband
+        </button>
+      </div>
+
+      {/* Stats row */}
+      {stats && (stats.mean > 0 || stats.peak > 0) && (
+        <div className="flex gap-3 border-t border-border/40 px-2.5 py-1.5">
+          <span className="font-mono text-[9px] text-muted-foreground">
+            avg{" "}
+            <span className="text-foreground">{stats.mean.toFixed(1)}</span>
+            <span className="text-muted-foreground/60">A</span>
+          </span>
+          <span className="font-mono text-[9px] text-muted-foreground">
+            pk{" "}
+            <span className="text-foreground">{stats.peak.toFixed(1)}</span>
+            <span className="text-muted-foreground/60">A</span>
+          </span>
+        </div>
+      )}
+
+      {/* Collapsible channel list */}
+      {open && (
+        <ul className="border-t border-border px-3 py-2 space-y-0.5">
+          {channels.length === 0 ? (
+            <li className="font-mono text-[10px] text-muted-foreground/50">No channels assigned</li>
+          ) : (
+            channels.map(({ ch, label }) => (
+              <li key={ch} className="flex items-center gap-1.5 font-mono text-[10px]">
+                <span className="text-muted-foreground text-[8px]">•</span>
+                <span className={label ? "text-foreground" : "text-muted-foreground"}>
+                  {label || `CH ${ch}`}
+                </span>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── DropZone ──────────────────────────────────────────────────────────────────
+
+interface DropZoneProps {
+  name: string;
+  label: string;
+  color: string;
+  channels: number[];
+  config: PDHConfig;
+  hasChannelData: boolean;
+  channelMeans: Record<number, number>;
+  channelPeaks: Record<number, number>;
+  isDragOver: boolean;
+  onDragEnter: () => void;
+  onDragLeave: () => void;
+  onDrop: () => void;
+  onDragStart: (ch: number) => void;
+  onDragEnd: () => void;
+  onLabelChange: (ch: number, label: string) => void;
+}
+
+function DropZone({
+  label, color, channels, config, hasChannelData, channelMeans, channelPeaks,
+  isDragOver, onDragEnter, onDragLeave, onDrop, onDragStart, onDragEnd, onLabelChange,
+}: DropZoneProps) {
+  return (
+    <div
+      className="rounded-lg border transition-colors"
+      style={isDragOver ? { borderColor: color, backgroundColor: `${color}12` } : { borderColor: "var(--border)" }}
+      onDragOver={(e) => e.preventDefault()}
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      <div className="flex items-center gap-2 rounded-t-lg px-3 py-2" style={{ backgroundColor: `${color}18` }}>
+        <span className="h-2 w-2 flex-shrink-0 rounded-full" style={{ backgroundColor: color }} />
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-wider" style={{ color }}>
+          {label}
+        </span>
+        <span className="ml-auto font-mono text-[10px] text-muted-foreground">{channels.length} ch</span>
+      </div>
+
+      <div className="flex min-h-[60px] flex-wrap gap-2 p-3">
+        {channels.length === 0 && (
+          <p className="w-full self-center text-center font-mono text-[10px] text-muted-foreground/40">
+            Drag channels here
+          </p>
+        )}
+        {channels.map((ch) => (
+          <ChannelCard
+            key={ch}
+            ch={ch}
+            label={config.channels[ch]?.label ?? ""}
+            hasChannelData={hasChannelData}
+            mean={channelMeans[ch] ?? 0}
+            peak={channelPeaks[ch] ?? 0}
+            onLabelChange={(l) => onLabelChange(ch, l)}
+            onDragStart={() => onDragStart(ch)}
+            onDragEnd={onDragEnd}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── ChannelCard ───────────────────────────────────────────────────────────────
+
+interface ChannelCardProps {
+  ch: number;
+  label: string;
+  hasChannelData: boolean;
+  mean: number;
+  peak: number;
+  onLabelChange: (label: string) => void;
+  onDragStart: () => void;
+  onDragEnd: () => void;
+}
+
+function ChannelCard({ ch, label, hasChannelData, mean, peak, onLabelChange, onDragStart, onDragEnd }: ChannelCardProps) {
+  const breaker = getChannelBreaker(ch);
+  return (
+    <div
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      className="flex cursor-grab flex-col gap-1 rounded border border-border bg-card px-2.5 py-2 active:cursor-grabbing active:opacity-60"
+    >
+      <div className="flex items-center gap-1.5">
+        <span className="select-none text-[8px] text-muted-foreground/40">⠿</span>
+        <span className="rounded bg-primary/10 px-1 py-0.5 font-mono text-[9px] font-semibold text-primary">
+          CH {ch}
+        </span>
+        <span className={`rounded px-1 py-0.5 font-mono text-[8px] ${
+          breaker === "HIGH" ? "bg-blue-500/10 text-blue-400"
+            : breaker === "LOW-SW" ? "bg-amber-500/10 text-amber-400"
+            : "bg-emerald-500/10 text-emerald-400"
+        }`}>
+          {breaker}
+        </span>
+      </div>
+
+      {hasChannelData && (
+        <p className="font-mono text-[10px] text-foreground">
+          {mean.toFixed(1)}<span className="text-muted-foreground">A</span>
+          <span className="ml-1 text-[9px] text-muted-foreground">{peak.toFixed(1)}pk</span>
+        </p>
+      )}
+
+      <input
+        type="text"
+        placeholder="Label…"
+        value={label}
+        onChange={(e) => onLabelChange(e.target.value)}
+        onClick={(e) => e.stopPropagation()}
+        onDragStart={(e) => e.stopPropagation()}
+        className="w-24 rounded border border-border bg-background px-1 py-0.5 font-mono text-[10px] text-foreground placeholder-muted-foreground/40 focus:border-primary/50 focus:outline-none"
+      />
+    </div>
+  );
+}

--- a/apps/juice/src/components/pdh/PDHConfigApp.tsx
+++ b/apps/juice/src/components/pdh/PDHConfigApp.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  loadPDHConfig,
+  savePDHConfig,
+  defaultPDHConfig,
+  type PDHConfig,
+  type SubsystemConfig,
+  PDH_CHANNEL_COUNT,
+  PDH_COLORS,
+  getChannelBreaker,
+} from "@/services/pdh/config";
+
+export function PDHConfigApp() {
+  const [config, setConfig] = useState<PDHConfig>(() => loadPDHConfig());
+  const [saved, setSaved] = useState(false);
+
+  const persist = useCallback((next: PDHConfig) => {
+    setConfig(next);
+    savePDHConfig(next);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 1500);
+  }, []);
+
+  // ── Subsystem management ─────────────────────────────────────
+
+  const addSubsystem = () => {
+    const idx = config.subsystems.length % PDH_COLORS.length;
+    persist({
+      ...config,
+      subsystems: [
+        ...config.subsystems,
+        { name: `Subsystem ${config.subsystems.length + 1}`, color: PDH_COLORS[idx] ?? "#3b82f6", weight: 0 },
+      ],
+    });
+  };
+
+  const updateSubsystem = (i: number, patch: Partial<SubsystemConfig>) => {
+    const subs = [...config.subsystems];
+    subs[i] = { ...subs[i]!, ...patch };
+    persist({ ...config, subsystems: subs });
+  };
+
+  const renameSubsystem = (oldName: string, newName: string) => {
+    persist({
+      ...config,
+      subsystems: config.subsystems.map((s) => (s.name === oldName ? { ...s, name: newName } : s)),
+      channels: config.channels.map((ch) =>
+        ch.subsystem === oldName ? { ...ch, subsystem: newName } : ch
+      ),
+    });
+  };
+
+  const deleteSubsystem = (name: string) => {
+    persist({
+      ...config,
+      subsystems: config.subsystems.filter((s) => s.name !== name),
+      channels: config.channels.map((ch) =>
+        ch.subsystem === name ? { ...ch, subsystem: "" } : ch
+      ),
+    });
+  };
+
+  const resetAll = () => persist(defaultPDHConfig());
+
+  // ── Channel label editing ─────────────────────────────────────
+
+  const setLabel = (ch: number, label: string) => {
+    const channels = [...config.channels];
+    channels[ch] = { ...channels[ch]!, label };
+    persist({ ...config, channels });
+  };
+
+  // ── Drag-and-drop ─────────────────────────────────────────────
+
+  const [dragging, setDragging] = useState<number | null>(null); // channel index being dragged
+  const [dragOver, setDragOver] = useState<string | null>(null); // subsystem name (or "__unassigned")
+  const dragCounters = useRef<Record<string, number>>({});
+
+  const handleDragStart = (ch: number) => setDragging(ch);
+  const handleDragEnd = () => { setDragging(null); setDragOver(null); };
+
+  const handleDragEnter = (zone: string) => {
+    dragCounters.current[zone] = (dragCounters.current[zone] ?? 0) + 1;
+    setDragOver(zone);
+  };
+
+  const handleDragLeave = (zone: string) => {
+    dragCounters.current[zone] = (dragCounters.current[zone] ?? 1) - 1;
+    if ((dragCounters.current[zone] ?? 0) <= 0) {
+      dragCounters.current[zone] = 0;
+      setDragOver((prev) => (prev === zone ? null : prev));
+    }
+  };
+
+  const handleDrop = (zone: string) => {
+    if (dragging === null) return;
+    const newSubsystem = zone === "__unassigned" ? "" : zone;
+    const channels = [...config.channels];
+    channels[dragging] = { ...channels[dragging]!, subsystem: newSubsystem };
+    persist({ ...config, channels });
+    dragCounters.current = {};
+    setDragOver(null);
+  };
+
+  const totalWeight = config.subsystems.reduce((s, sub) => s + sub.weight, 0);
+
+  // Channels by zone
+  const channelsByZone = (zoneName: string) =>
+    Array.from({ length: PDH_CHANNEL_COUNT }, (_, i) => i).filter((ch) => {
+      const cfg = config.channels[ch];
+      const sub = cfg?.subsystem ?? "";
+      return zoneName === "__unassigned" ? sub === "" : sub === zoneName;
+    });
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      {/* Top bar */}
+      <header className="sticky top-0 z-10 flex items-center gap-3 border-b border-border bg-background/95 px-6 py-3 backdrop-blur">
+        <a href="/analyzer" className="font-mono text-xs text-muted-foreground hover:text-primary">
+          ← Back to Analyzer
+        </a>
+        <span className="ml-2 font-mono text-sm font-semibold text-primary">PDH Configuration</span>
+        {saved && (
+          <span className="ml-auto rounded bg-emerald-500/10 px-2 py-0.5 font-mono text-[10px] text-emerald-400">
+            Saved ✓
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={resetAll}
+          className="ml-auto rounded border border-border px-3 py-1 font-mono text-[10px] text-muted-foreground hover:border-destructive/40 hover:text-destructive"
+        >
+          Reset all
+        </button>
+      </header>
+
+      <div className="mx-auto flex max-w-[1400px] gap-6 p-6">
+        {/* ── Left panel: subsystem definitions ── */}
+        <aside className="w-72 flex-shrink-0">
+          <div className="rounded-lg border border-border bg-card p-4">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                Subsystems
+              </h2>
+              <span
+                className={`rounded px-2 py-0.5 font-mono text-[10px] font-semibold ${
+                  totalWeight === 100
+                    ? "bg-emerald-500/10 text-emerald-400"
+                    : totalWeight > 100
+                      ? "bg-red-500/10 text-red-400"
+                      : "bg-muted text-muted-foreground"
+                }`}
+              >
+                Σ {totalWeight}%
+              </span>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              {config.subsystems.map((sub, i) => (
+                <SubsystemRow
+                  key={sub.name}
+                  sub={sub}
+                  onColorChange={(color) => updateSubsystem(i, { color })}
+                  onNameChange={(name) => renameSubsystem(sub.name, name)}
+                  onWeightChange={(weight) => updateSubsystem(i, { weight })}
+                  onDelete={() => deleteSubsystem(sub.name)}
+                />
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={addSubsystem}
+              className="mt-3 w-full rounded border border-dashed border-border py-1.5 font-mono text-[10px] text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+            >
+              + Add subsystem
+            </button>
+
+            <p className="mt-4 text-[10px] leading-relaxed text-muted-foreground">
+              Drag channel cards on the right into subsystem zones. Weight % is used for estimated
+              current breakdown when no per-channel log data is available.
+            </p>
+          </div>
+        </aside>
+
+        {/* ── Right panel: drop zones ── */}
+        <main className="min-w-0 flex-1">
+          {/* Unassigned zone */}
+          <DropZone
+            name="__unassigned"
+            label="Unassigned"
+            color="#6b7280"
+            channels={channelsByZone("__unassigned")}
+            config={config}
+            isDragOver={dragOver === "__unassigned"}
+            onDragEnter={() => handleDragEnter("__unassigned")}
+            onDragLeave={() => handleDragLeave("__unassigned")}
+            onDrop={() => handleDrop("__unassigned")}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onLabelChange={setLabel}
+          />
+
+          {config.subsystems.map((sub) => (
+            <DropZone
+              key={sub.name}
+              name={sub.name}
+              label={sub.name}
+              color={sub.color}
+              channels={channelsByZone(sub.name)}
+              config={config}
+              isDragOver={dragOver === sub.name}
+              onDragEnter={() => handleDragEnter(sub.name)}
+              onDragLeave={() => handleDragLeave(sub.name)}
+              onDrop={() => handleDrop(sub.name)}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              onLabelChange={setLabel}
+            />
+          ))}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+// ── SubsystemRow ──────────────────────────────────────────────────────────────
+
+interface SubsystemRowProps {
+  sub: SubsystemConfig;
+  onColorChange: (color: string) => void;
+  onNameChange: (name: string) => void;
+  onWeightChange: (weight: number) => void;
+  onDelete: () => void;
+}
+
+function SubsystemRow({ sub, onColorChange, onNameChange, onWeightChange, onDelete }: SubsystemRowProps) {
+  const colorRef = useRef<HTMLInputElement>(null);
+  const [editName, setEditName] = useState(sub.name);
+
+  return (
+    <div className="flex items-center gap-2 rounded border border-border bg-background px-2 py-1.5">
+      {/* Color circle */}
+      <button
+        type="button"
+        onClick={() => colorRef.current?.click()}
+        className="h-4 w-4 flex-shrink-0 cursor-pointer rounded-full border border-border/50 transition-transform hover:scale-110"
+        style={{ backgroundColor: sub.color }}
+        title="Change color"
+      />
+      <input
+        ref={colorRef}
+        type="color"
+        value={sub.color}
+        onChange={(e) => onColorChange(e.target.value)}
+        className="sr-only"
+      />
+
+      {/* Name */}
+      <input
+        type="text"
+        value={editName}
+        onChange={(e) => setEditName(e.target.value)}
+        onBlur={() => { if (editName.trim()) onNameChange(editName.trim()); else setEditName(sub.name); }}
+        className="min-w-0 flex-1 bg-transparent font-mono text-[11px] text-foreground focus:outline-none"
+      />
+
+      {/* Weight */}
+      <input
+        type="number"
+        min={0}
+        max={100}
+        value={sub.weight}
+        onChange={(e) => onWeightChange(Number(e.target.value))}
+        className="w-10 rounded border border-border bg-card px-1 py-0.5 text-center font-mono text-[10px] text-foreground focus:border-primary/50 focus:outline-none"
+      />
+      <span className="font-mono text-[9px] text-muted-foreground">%</span>
+
+      <button
+        type="button"
+        onClick={onDelete}
+        className="rounded px-1 font-mono text-[11px] text-muted-foreground hover:text-destructive"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+// ── DropZone ──────────────────────────────────────────────────────────────────
+
+interface DropZoneProps {
+  name: string;
+  label: string;
+  color: string;
+  channels: number[];
+  config: PDHConfig;
+  isDragOver: boolean;
+  onDragEnter: () => void;
+  onDragLeave: () => void;
+  onDrop: () => void;
+  onDragStart: (ch: number) => void;
+  onDragEnd: () => void;
+  onLabelChange: (ch: number, label: string) => void;
+}
+
+function DropZone({
+  name,
+  label,
+  color,
+  channels,
+  config,
+  isDragOver,
+  onDragEnter,
+  onDragLeave,
+  onDrop,
+  onDragStart,
+  onDragEnd,
+  onLabelChange,
+}: DropZoneProps) {
+  return (
+    <div
+      className="mb-4 rounded-lg border border-border transition-colors"
+      style={isDragOver ? { borderColor: color, backgroundColor: color + "10" } : undefined}
+      onDragOver={(e) => e.preventDefault()}
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      <div
+        className="flex items-center gap-2 rounded-t-lg px-3 py-2"
+        style={{ backgroundColor: color + "18" }}
+      >
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: color }} />
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-wider" style={{ color }}>
+          {label}
+        </span>
+        <span className="ml-auto font-mono text-[10px] text-muted-foreground">
+          {channels.length} ch
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-2 p-3">
+        {channels.length === 0 && (
+          <p className="w-full py-2 text-center font-mono text-[10px] text-muted-foreground/50">
+            Drop channels here
+          </p>
+        )}
+        {channels.map((ch) => (
+          <ChannelCard
+            key={ch}
+            ch={ch}
+            label={config.channels[ch]?.label ?? ""}
+            onLabelChange={(l) => onLabelChange(ch, l)}
+            onDragStart={() => onDragStart(ch)}
+            onDragEnd={onDragEnd}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── ChannelCard ───────────────────────────────────────────────────────────────
+
+interface ChannelCardProps {
+  ch: number;
+  label: string;
+  onLabelChange: (label: string) => void;
+  onDragStart: () => void;
+  onDragEnd: () => void;
+}
+
+function ChannelCard({ ch, label, onLabelChange, onDragStart, onDragEnd }: ChannelCardProps) {
+  const breaker = getChannelBreaker(ch);
+  return (
+    <div
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      className="flex cursor-grab items-center gap-2 rounded border border-border bg-card px-2 py-1.5 active:cursor-grabbing"
+    >
+      {/* Drag handle dots */}
+      <span className="select-none text-muted-foreground/40" style={{ fontSize: 9, letterSpacing: 1 }}>
+        ⠿
+      </span>
+
+      <span className="rounded bg-primary/10 px-1 py-0.5 font-mono text-[9px] font-semibold text-primary">
+        {ch}
+      </span>
+
+      <span
+        className={`rounded px-1 py-0.5 font-mono text-[8px] ${
+          breaker === "HIGH"
+            ? "bg-blue-500/10 text-blue-400"
+            : breaker === "LOW-SW"
+              ? "bg-amber-500/10 text-amber-400"
+              : "bg-emerald-500/10 text-emerald-400"
+        }`}
+      >
+        {breaker}
+      </span>
+
+      <input
+        type="text"
+        placeholder="Label…"
+        value={label}
+        onChange={(e) => onLabelChange(e.target.value)}
+        onClick={(e) => e.stopPropagation()}
+        onDragStart={(e) => e.stopPropagation()}
+        className="w-28 bg-transparent font-mono text-[10px] text-foreground placeholder-muted-foreground/40 focus:outline-none"
+      />
+    </div>
+  );
+}

--- a/apps/juice/src/pages/index.astro
+++ b/apps/juice/src/pages/index.astro
@@ -22,7 +22,7 @@ import "../styles/globals.css";
 				<a href="/tracker" class="whitespace-nowrap border-b-2 border-transparent px-4 py-2.5 font-mono text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground">Tracker</a>
 			</nav>
 		</div>
-		<div class="flex min-h-[calc(100vh-3.5rem)] flex-col items-center justify-center px-6 py-12">
+		<div class="flex min-h-screen flex-col items-center justify-center px-6 py-12">
 			<h1 class="mb-3 text-center text-3xl font-medium tracking-tight text-foreground">
 				FRC Battery Tools
 			</h1>

--- a/apps/juice/src/pages/pdh-config.astro
+++ b/apps/juice/src/pages/pdh-config.astro
@@ -1,0 +1,19 @@
+---
+import "../styles/globals.css";
+// biome-ignore lint/correctness/noUnusedImports: used in Astro template below
+import { PDHConfigApp } from "../components/pdh/PDHConfigApp";
+---
+
+<html lang="en" class="dark">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Juice — PDH Configuration</title>
+	</head>
+	<body class="min-h-screen bg-background text-foreground">
+		<PDHConfigApp client:only="react" />
+	</body>
+</html>

--- a/apps/juice/src/services/analysis/demo.ts
+++ b/apps/juice/src/services/analysis/demo.ts
@@ -2,23 +2,29 @@ import type { CANCurrentPoint, DSVoltagePoint } from "./types";
 
 /**
  * Generate synthetic match data for demo purposes.
- * Simulates ~160s match with realistic voltage sag and current profiles.
+ * Simulates ~160s match with realistic voltage sag, current profiles,
+ * and per-channel PDH current for 24 channels.
  */
 export function generateDemoData(): {
   dsData: DSVoltagePoint[];
   canData: CANCurrentPoint[];
+  channels: Record<string, number[]>;
 } {
   const dsData: DSVoltagePoint[] = [];
   const canData: CANCurrentPoint[] = [];
+  const chArrays: number[][] = Array.from({ length: 24 }, () => []);
+
   let soc = 0.91;
   let t = 0;
 
   for (let i = 0; i < 8000; i++) {
-    // Current load profile: pre-match idle → auto → teleop
+    const isAuto = i >= 250 && i < 1000;
+    const isTeleop = i >= 1000;
+
     let load: number;
     if (i < 250) {
       load = 8 + Math.random() * 4;
-    } else if (i < 1000) {
+    } else if (isAuto) {
       load = 70 + Math.sin(i * 0.2) * 40 + (Math.random() < 0.08 ? 140 : 0) + Math.random() * 10;
     } else {
       load =
@@ -32,12 +38,8 @@ export function generateDemoData(): {
     const imp = 0.013 + (1 - soc) * 0.028 + (Math.random() - 0.5) * 0.003;
     const v = Math.max(6.1, 12.6 * soc - load * imp + (Math.random() - 0.5) * 0.07);
 
-    dsData.push({
-      t: Number(t.toFixed(3)),
-      v: Number(v.toFixed(4)),
-    });
+    dsData.push({ t: Number(t.toFixed(3)), v: Number(v.toFixed(4)) });
 
-    // Split total load across 6 CAN devices
     canData.push({
       t: Number(t.toFixed(3)),
       current: Number(
@@ -52,9 +54,50 @@ export function generateDemoData(): {
       ),
     });
 
+    // Per-channel synthetic currents
+    const drive = isAuto || isTeleop ? load * 0.12 : load * 0.03;
+    const turn  = isAuto || isTeleop ? load * 0.03 : 0.5;
+    const arm   = isTeleop && Math.random() < 0.4 ? load * 0.08 : 1;
+    const intake = isTeleop && Math.random() < 0.3 ? load * 0.04 : 0.5;
+    const shooter = isTeleop && Math.random() < 0.25 ? load * 0.1 : 0.2;
+    const climber = i > 7200 ? load * 0.15 : 0;
+    const rand = (s: number) => Math.max(0, (Math.random() - 0.4) * s);
+
+    // CH 0-3: drive motors
+    for (let ch = 0; ch < 4; ch++) chArrays[ch]!.push(+(drive + rand(4)).toFixed(2));
+    // CH 4-7: turn motors
+    for (let ch = 4; ch < 8; ch++) chArrays[ch]!.push(+(turn + rand(1.5)).toFixed(2));
+    // CH 8-9: arm pivot
+    for (let ch = 8; ch < 10; ch++) chArrays[ch]!.push(+(arm + rand(2)).toFixed(2));
+    // CH 10-11: arm extend / wrist
+    for (let ch = 10; ch < 12; ch++) chArrays[ch]!.push(+(arm * 0.7 + rand(1.5)).toFixed(2));
+    // CH 12-13: intake
+    for (let ch = 12; ch < 14; ch++) chArrays[ch]!.push(+(intake + rand(1)).toFixed(2));
+    // CH 14-15: shooter flywheel
+    for (let ch = 14; ch < 16; ch++) chArrays[ch]!.push(+(shooter + rand(2)).toFixed(2));
+    // CH 16-17: climber
+    for (let ch = 16; ch < 18; ch++) chArrays[ch]!.push(+(climber + rand(1)).toFixed(2));
+    // CH 18: feeder
+    chArrays[18]!.push(+(intake * 0.5 + rand(0.5)).toFixed(2));
+    // CH 19: spare
+    chArrays[19]!.push(0);
+    // CH 20: compressor (cycles on ~30% of the time)
+    chArrays[20]!.push(Math.sin(i * 0.03) > 0.4 ? +(18 + rand(2)).toFixed(2) : 0);
+    // CH 21: LED
+    chArrays[21]!.push(+(0.8 + rand(0.2)).toFixed(2));
+    // CH 22: vision co-processor
+    chArrays[22]!.push(+(4.5 + rand(0.5)).toFixed(2));
+    // CH 23: radio (always-on)
+    chArrays[23]!.push(+(2.8 + rand(0.3)).toFixed(2));
+
     soc -= load * 1e-7;
     t += 0.02;
   }
 
-  return { dsData, canData };
+  const channels: Record<string, number[]> = {};
+  for (let ch = 0; ch < 24; ch++) {
+    channels[`CH ${ch}`] = chArrays[ch]!;
+  }
+
+  return { dsData, canData, channels };
 }

--- a/apps/juice/src/services/analysis/parse-voltage.ts
+++ b/apps/juice/src/services/analysis/parse-voltage.ts
@@ -1,26 +1,22 @@
 import { DSLogParser } from "../dslog";
-import type { CANCurrentPoint, DSVoltagePoint } from "./types";
+import { parseWPILog } from "../wpilog";
+import type { CANCurrentPoint, DSLogParseResult, DSVoltagePoint } from "./types";
 
-export interface DSLogParseResult {
-  voltage: DSVoltagePoint[];
-  current: CANCurrentPoint[];
-  /** Per-channel current arrays, keyed by channel name */
-  channels: Record<string, number[]>;
-}
+export type { DSLogParseResult };
 
 /**
- * Parse a DS Log file using the proper DSLogParser.
- * Extracts both voltage and total current (sum of PDP channels).
- * Falls back to CSV parsing for non-.dslog files.
+ * Parse a DS Log or WPILog file.
+ * - .dslog  → binary DSLog parser (voltage + PDP/PDH channels)
+ * - .wpilog → WPILog v1.0 parser (voltage + PDH channels + total current)
+ * - other   → CSV fallback (voltage only)
  */
 export function parseDSFile(fileName: string, buffer: ArrayBuffer): DSLogParseResult | null {
   const lower = fileName.toLowerCase();
 
-  if (lower.endsWith(".dslog")) {
-    return parseDSLogBinary(buffer);
-  }
+  if (lower.endsWith(".dslog")) return parseDSLogBinary(buffer);
+  if (lower.endsWith(".wpilog")) return parseWPILog(buffer);
 
-  // CSV fallback — voltage only (no PDP channel data in CSV exports)
+  // CSV fallback — voltage only
   const text = new TextDecoder().decode(buffer);
   const voltage = parseDSCSV(text);
   if (!voltage) return null;
@@ -34,12 +30,10 @@ function parseDSLogBinary(buffer: ArrayBuffer): DSLogParseResult | null {
     const result = parser.parse(buffer);
     if (result.records.length < 10) return null;
 
-    const _startTs = result.records[0]?.timestamp;
-
     const voltage: DSVoltagePoint[] = [];
     const current: CANCurrentPoint[] = [];
 
-    // Filter to only auto/teleop periods (skip disabled/disconnected)
+    // Filter to only auto/teleop periods
     const enabled = result.records.filter(
       (r) => (r.robotAuto || r.robotTeleop) && r.voltageV > 0 && r.voltageV <= 20
     );

--- a/apps/juice/src/services/analysis/phases.ts
+++ b/apps/juice/src/services/analysis/phases.ts
@@ -1,0 +1,104 @@
+import type { MergedData } from "./types";
+import type { PDHConfig } from "../pdh/config";
+
+export interface PhaseSegment {
+  subsystem: string;
+  color: string;
+  startT: number;
+  endT: number;
+}
+
+interface PhaseOptions {
+  /** Fraction of subsystem peak current to use as active threshold (default 0.15) */
+  thresholdFraction?: number;
+  /** Minimum absolute current (A) to count as active, guards against noise (default 3) */
+  minAbsoluteA?: number;
+  /** Smoothing window in samples (default 10) */
+  smoothWindow?: number;
+  /** Merge gaps shorter than this (seconds) into one segment (default 0.4) */
+  mergeGapS?: number;
+  /** Discard segments shorter than this (seconds) (default 0.2) */
+  minDurationS?: number;
+}
+
+export function detectPhases(
+  data: MergedData,
+  config: PDHConfig,
+  options: PhaseOptions = {}
+): PhaseSegment[] {
+  const {
+    thresholdFraction = 0.15,
+    minAbsoluteA = 3,
+    smoothWindow = 10,
+    mergeGapS = 0.4,
+    minDurationS = 0.2,
+  } = options;
+
+  const segments: PhaseSegment[] = [];
+  const n = data.times.length;
+  if (n === 0) return segments;
+
+  for (const sub of config.subsystems) {
+    const chIndices = config.channels
+      .map((ch, idx) => (ch.subsystem === sub.name ? idx : -1))
+      .filter((idx) => idx !== -1);
+
+    if (chIndices.length === 0) continue;
+
+    // Sum channel currents at each sample
+    const raw = Array.from({ length: n }, (_, i) =>
+      chIndices.reduce((sum, ch) => sum + (data.channels[`CH ${ch}`]?.[i] ?? 0), 0)
+    );
+
+    // Rolling mean smoothing
+    const smoothed = new Array(n).fill(0) as number[];
+    for (let i = 0; i < n; i++) {
+      const lo = Math.max(0, i - smoothWindow);
+      let s = 0;
+      for (let j = lo; j <= i; j++) s += raw[j] ?? 0;
+      smoothed[i] = s / (i - lo + 1);
+    }
+
+    const peak = Math.max(...smoothed);
+    const threshold = Math.max(minAbsoluteA, peak * thresholdFraction);
+
+    // Build boolean active mask
+    const active = smoothed.map((v) => v >= threshold);
+
+    // Convert mask to raw segments
+    const raw_segs: { startT: number; endT: number }[] = [];
+    let inSeg = false;
+    let segStart = 0;
+
+    for (let i = 0; i < n; i++) {
+      if (!inSeg && active[i]) {
+        inSeg = true;
+        segStart = data.times[i] ?? 0;
+      } else if (inSeg && !active[i]) {
+        inSeg = false;
+        raw_segs.push({ startT: segStart, endT: data.times[i - 1] ?? segStart });
+      }
+    }
+    if (inSeg) raw_segs.push({ startT: segStart, endT: data.times[n - 1] ?? segStart });
+
+    // Merge close segments
+    const merged: { startT: number; endT: number }[] = [];
+    for (const seg of raw_segs) {
+      const prev = merged[merged.length - 1];
+      if (prev && seg.startT - prev.endT <= mergeGapS) {
+        prev.endT = seg.endT;
+      } else {
+        merged.push({ ...seg });
+      }
+    }
+
+    // Filter short segments and emit
+    for (const seg of merged) {
+      if (seg.endT - seg.startT >= minDurationS) {
+        segments.push({ subsystem: sub.name, color: sub.color, startT: seg.startT, endT: seg.endT });
+      }
+    }
+  }
+
+  return segments.sort((a, b) => a.startT - b.startT);
+}

--- a/apps/juice/src/services/analysis/types.ts
+++ b/apps/juice/src/services/analysis/types.ts
@@ -3,6 +3,13 @@ export interface DSVoltagePoint {
   v: number;
 }
 
+export interface DSLogParseResult {
+  voltage: DSVoltagePoint[];
+  current: CANCurrentPoint[];
+  /** Per-channel current arrays aligned to the voltage timeline, keyed by "CH N" */
+  channels: Record<string, number[]>;
+}
+
 export interface CANCurrentPoint {
   t: number;
   current: number;

--- a/apps/juice/src/services/pdh/config.ts
+++ b/apps/juice/src/services/pdh/config.ts
@@ -1,0 +1,136 @@
+const STORAGE_KEY = "yetiPdhConfig";
+
+export const PDH_CHANNEL_COUNT = 24;
+export const PDH_HIGH_COUNT = 20;  // CH 0-19: 40A high-current
+export const PDH_LOW_SW = 3;       // CH 20-22: 20A switchable
+export const PDH_LOW_AON = 1;      // CH 23: 20A always-on
+
+export const PDH_COLORS = [
+  "#3b82f6", "#10b981", "#f59e0b", "#ef4444",
+  "#8b5cf6", "#06b6d4", "#f97316", "#ec4899",
+  "#84cc16", "#14b8a6", "#f43f5e", "#a855f7",
+];
+
+export interface ChannelConfig {
+  label: string;
+  subsystem: string;
+}
+
+export interface SubsystemConfig {
+  name: string;
+  color: string;
+  weight: number;
+}
+
+export interface PDHConfig {
+  channels: ChannelConfig[];   // always 24 entries
+  subsystems: SubsystemConfig[];
+}
+
+export function getChannelBreaker(ch: number): "HIGH" | "LOW-SW" | "AON" {
+  if (ch < PDH_HIGH_COUNT) return "HIGH";
+  if (ch < PDH_HIGH_COUNT + PDH_LOW_SW) return "LOW-SW";
+  return "AON";
+}
+
+function ensureLength(channels: ChannelConfig[]): ChannelConfig[] {
+  const arr = [...channels];
+  while (arr.length < PDH_CHANNEL_COUNT) arr.push({ label: "", subsystem: "" });
+  return arr.slice(0, PDH_CHANNEL_COUNT);
+}
+
+export function defaultPDHConfig(): PDHConfig {
+  return {
+    channels: Array.from({ length: PDH_CHANNEL_COUNT }, () => ({ label: "", subsystem: "" })),
+    subsystems: [],
+  };
+}
+
+export function loadPDHConfig(): PDHConfig {
+  if (typeof window === "undefined") return defaultPDHConfig();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultPDHConfig();
+    const parsed = JSON.parse(raw) as PDHConfig;
+    parsed.channels = ensureLength(parsed.channels ?? []);
+    parsed.subsystems = parsed.subsystems ?? [];
+    return parsed;
+  } catch {
+    return defaultPDHConfig();
+  }
+}
+
+export function savePDHConfig(config: PDHConfig): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+}
+
+export function exportPDHConfig(config: PDHConfig): void {
+  const blob = new Blob([JSON.stringify(config, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "pdh-config.json";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function importPDHConfig(file: File): Promise<PDHConfig> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const parsed = JSON.parse(e.target?.result as string) as PDHConfig;
+        if (!Array.isArray(parsed.channels) || !Array.isArray(parsed.subsystems)) {
+          reject(new Error("Invalid PDH config file."));
+          return;
+        }
+        parsed.channels = ensureLength(parsed.channels);
+        resolve(parsed);
+      } catch {
+        reject(new Error("Could not parse JSON file."));
+      }
+    };
+    reader.onerror = () => reject(new Error("Failed to read file."));
+    reader.readAsText(file);
+  });
+}
+
+export function seedDemoConfig(): PDHConfig {
+  return {
+    channels: [
+      { label: "LF Drive Motor",      subsystem: "Drivetrain" },
+      { label: "RF Drive Motor",      subsystem: "Drivetrain" },
+      { label: "LB Drive Motor",      subsystem: "Drivetrain" },
+      { label: "RB Drive Motor",      subsystem: "Drivetrain" },
+      { label: "LF Turn Motor",       subsystem: "Drivetrain" },
+      { label: "RF Turn Motor",       subsystem: "Drivetrain" },
+      { label: "LB Turn Motor",       subsystem: "Drivetrain" },
+      { label: "RB Turn Motor",       subsystem: "Drivetrain" },
+      { label: "Arm Pivot 1",         subsystem: "Arm" },
+      { label: "Arm Pivot 2",         subsystem: "Arm" },
+      { label: "Arm Extend",          subsystem: "Arm" },
+      { label: "Wrist",               subsystem: "Arm" },
+      { label: "Intake Roller 1",     subsystem: "Intake" },
+      { label: "Intake Roller 2",     subsystem: "Intake" },
+      { label: "Shooter Flywheel 1",  subsystem: "Shooter" },
+      { label: "Shooter Flywheel 2",  subsystem: "Shooter" },
+      { label: "Climber 1",           subsystem: "Climber" },
+      { label: "Climber 2",           subsystem: "Climber" },
+      { label: "Feeder/Indexer",      subsystem: "Intake" },
+      { label: "Spare",               subsystem: "" },
+      { label: "Compressor",          subsystem: "Aux" },
+      { label: "LED Controller",      subsystem: "Aux" },
+      { label: "Vision Co-Processor", subsystem: "Aux" },
+      { label: "Radio (Always-On)",   subsystem: "Aux" },
+    ],
+    subsystems: [
+      { name: "Drivetrain", color: "#3b82f6", weight: 48 },
+      { name: "Arm",        color: "#10b981", weight: 20 },
+      { name: "Intake",     color: "#f59e0b", weight: 10 },
+      { name: "Shooter",    color: "#ef4444", weight: 12 },
+      { name: "Climber",    color: "#8b5cf6", weight: 5  },
+      { name: "Aux",        color: "#06b6d4", weight: 5  },
+    ],
+  };
+}

--- a/apps/juice/src/services/wpilog/index.ts
+++ b/apps/juice/src/services/wpilog/index.ts
@@ -1,0 +1,1 @@
+export { parseWPILog } from "./parser";

--- a/apps/juice/src/services/wpilog/parser.ts
+++ b/apps/juice/src/services/wpilog/parser.ts
@@ -1,0 +1,250 @@
+import type { CANCurrentPoint, DSLogParseResult, DSVoltagePoint } from "../analysis/types";
+
+const WPILOG_MAGIC = "WPILOG";
+
+function readUintLE(view: DataView, offset: number, size: number): number {
+  let val = 0;
+  for (let i = 0; i < size; i++) {
+    val += (view.getUint8(offset + i) ?? 0) * 2 ** (8 * i);
+  }
+  return val;
+}
+
+function readWpiString(view: DataView, offset: number): { value: string; byteLen: number } {
+  if (offset + 4 > view.byteLength) return { value: "", byteLen: 4 };
+  const len = view.getUint32(offset, true);
+  if (offset + 4 + len > view.byteLength) return { value: "", byteLen: 4 + len };
+  const bytes = new Uint8Array(view.buffer, view.byteOffset + offset + 4, len);
+  return { value: new TextDecoder().decode(bytes), byteLen: 4 + len };
+}
+
+function isVoltageEntry(name: string, type: string): boolean {
+  if (type !== "double" && type !== "float") return false;
+  const n = name.toLowerCase();
+  if (n === "/powerdistribution/inputvoltage") return true;
+  if (n.endsWith("/inputvoltage") || n.endsWith("/batteryvoltage")) return true;
+  if (n.includes("battery") && n.includes("voltage")) return true;
+  // Generic "voltage" but not per-motor/channel voltages
+  if (n.includes("voltage") && !n.match(/channel|motor|stator|supply|output|reverse/)) return true;
+  return false;
+}
+
+function isTotalCurrentEntry(name: string, type: string): boolean {
+  if (type !== "double" && type !== "float") return false;
+  const n = name.toLowerCase();
+  return (
+    n.includes("totalcurrent") ||
+    (n.endsWith("/current") && !n.match(/channel\d/))
+  );
+}
+
+function getChannelIndex(name: string, type: string): number | null {
+  if (type !== "double" && type !== "float") return null;
+  const m =
+    name.match(/[Cc]hannel(\d+)[Cc]urrent/) ??
+    name.match(/[Cc]hannel(\d+)/) ??
+    name.match(/\/[Cc][Hh](\d+)$/);
+  if (m?.[1] !== undefined) {
+    const ch = parseInt(m[1], 10);
+    if (ch >= 0 && ch < 24) return ch;
+  }
+  return null;
+}
+
+function isChannelArrayEntry(name: string, type: string): boolean {
+  if (type !== "double[]" && type !== "float[]") return false;
+  const n = name.toLowerCase();
+  return n.includes("channel") || (n.includes("current") && (n.includes("pdh") || n.includes("pdp")));
+}
+
+/**
+ * Parse a WPILog v1.0 binary file (.wpilog).
+ * Extracts voltage, total current, and per-channel PDH/PDP currents.
+ * Returns the same DSLogParseResult shape as the dslog parser.
+ */
+export function parseWPILog(buffer: ArrayBuffer): DSLogParseResult | null {
+  if (buffer.byteLength < 12) return null;
+
+  const view = new DataView(buffer);
+  const bytes = new Uint8Array(buffer);
+
+  // Validate magic bytes
+  const magic = String.fromCharCode(
+    bytes[0] ?? 0, bytes[1] ?? 0, bytes[2] ?? 0,
+    bytes[3] ?? 0, bytes[4] ?? 0, bytes[5] ?? 0,
+  );
+  if (magic !== WPILOG_MAGIC) return null;
+
+  // Only support v1.x
+  const version = view.getUint16(6, true);
+  if ((version >> 8) !== 1) return null;
+
+  const extraLen = view.getUint32(8, true);
+  let pos = 12 + extraLen;
+
+  // Entry registry
+  const entryTypes = new Map<number, string>(); // entryId -> type string
+
+  // Role assignments (determined from Start control records)
+  let voltageId = -1;
+  let totalCurrentId = -1;
+  const channelIdToChNum = new Map<number, number>(); // entryId -> channel 0-23
+  let channelArrayId = -1;
+
+  // Time series collectors
+  const voltPts: { us: number; v: number }[] = [];
+  const currPts: { us: number; c: number }[] = [];
+  const chPts = new Map<number, { us: number; v: number }[]>(); // chNum -> pts
+  const chArrayPts: { us: number; vs: number[] }[] = [];
+
+  while (pos < bytes.byteLength) {
+    const bf = bytes[pos++];
+    if (bf === undefined) break;
+
+    const idSize = (bf & 0x3) + 1;
+    const plSize = ((bf >> 2) & 0x3) + 1;
+    const tsSize = ((bf >> 4) & 0x7) + 1;
+
+    if (pos + idSize + plSize + tsSize > bytes.byteLength) break;
+
+    const entryId = readUintLE(view, pos, idSize);
+    pos += idSize;
+    const payloadSize = readUintLE(view, pos, plSize);
+    pos += plSize;
+    const timestampUs = readUintLE(view, pos, tsSize);
+    pos += tsSize;
+
+    const payloadStart = pos;
+    if (payloadStart + payloadSize > bytes.byteLength) break;
+
+    if (entryId === 0) {
+      // Control record
+      const ctrlType = bytes[payloadStart];
+      if (ctrlType === 0 && payloadSize >= 5) {
+        // Start record: register a new entry
+        const newId = view.getUint32(payloadStart + 1, true);
+        let sp = payloadStart + 5;
+        const { value: name, byteLen: nl } = readWpiString(view, sp);
+        sp += nl;
+        const { value: type } = readWpiString(view, sp);
+
+        entryTypes.set(newId, type);
+
+        // Assign a role based on name + type
+        if (voltageId === -1 && isVoltageEntry(name, type)) {
+          voltageId = newId;
+        } else if (totalCurrentId === -1 && isTotalCurrentEntry(name, type)) {
+          totalCurrentId = newId;
+        } else {
+          const ch = getChannelIndex(name, type);
+          if (ch !== null) {
+            channelIdToChNum.set(newId, ch);
+          } else if (channelArrayId === -1 && isChannelArrayEntry(name, type)) {
+            channelArrayId = newId;
+          }
+        }
+      }
+    } else {
+      // Data record
+      const type = entryTypes.get(entryId);
+      if (type) {
+        try {
+          const readScalar = (): number =>
+            type === "float"
+              ? view.getFloat32(payloadStart, true)
+              : view.getFloat64(payloadStart, true);
+
+          if (entryId === voltageId) {
+            const v = readScalar();
+            if (Number.isFinite(v) && v > 3 && v < 16) {
+              voltPts.push({ us: timestampUs, v });
+            }
+          } else if (entryId === totalCurrentId) {
+            const c = readScalar();
+            if (Number.isFinite(c) && c >= 0 && c < 1000) {
+              currPts.push({ us: timestampUs, c });
+            }
+          } else if (channelIdToChNum.has(entryId)) {
+            const chNum = channelIdToChNum.get(entryId)!;
+            const c = readScalar();
+            if (Number.isFinite(c)) {
+              let arr = chPts.get(chNum);
+              if (!arr) { arr = []; chPts.set(chNum, arr); }
+              arr.push({ us: timestampUs, v: c });
+            }
+          } else if (entryId === channelArrayId) {
+            const count = view.getUint32(payloadStart, true);
+            const stride = type === "float[]" ? 4 : 8;
+            const vs: number[] = [];
+            for (let i = 0; i < count; i++) {
+              const off = payloadStart + 4 + i * stride;
+              vs.push(type === "float[]" ? view.getFloat32(off, true) : view.getFloat64(off, true));
+            }
+            chArrayPts.push({ us: timestampUs, vs });
+          }
+        } catch {
+          // skip malformed payload
+        }
+      }
+    }
+
+    pos = payloadStart + payloadSize;
+  }
+
+  if (voltPts.length < 10) return null;
+
+  voltPts.sort((a, b) => a.us - b.us);
+  const startUs = voltPts[0]!.us;
+
+  const voltage: DSVoltagePoint[] = voltPts.map((p) => ({
+    t: +((p.us - startUs) / 1_000_000).toFixed(3),
+    v: +p.v.toFixed(4),
+  }));
+
+  const current: CANCurrentPoint[] = currPts
+    .sort((a, b) => a.us - b.us)
+    .map((p) => ({
+      t: +((p.us - startUs) / 1_000_000).toFixed(3),
+      current: +p.c.toFixed(3),
+    }));
+
+  const channels: Record<string, number[]> = {};
+
+  if (chPts.size > 0) {
+    for (const [chNum, pts] of chPts) {
+      pts.sort((a, b) => a.us - b.us);
+      channels[`CH ${chNum}`] = resampleToTimeline(pts, voltPts);
+    }
+  } else if (chArrayPts.length > 0) {
+    chArrayPts.sort((a, b) => a.us - b.us);
+    const numCh = Math.max(...chArrayPts.map((p) => p.vs.length));
+    for (let ch = 0; ch < numCh; ch++) {
+      const pts = chArrayPts.map((p) => ({ us: p.us, v: p.vs[ch] ?? 0 }));
+      channels[`CH ${ch}`] = resampleToTimeline(pts, voltPts);
+    }
+  }
+
+  return { voltage, current, channels };
+}
+
+function resampleToTimeline(
+  src: { us: number; v: number }[],
+  target: { us: number }[],
+): number[] {
+  if (src.length === 0) return target.map(() => 0);
+  const result: number[] = [];
+  let si = 0;
+  for (const tp of target) {
+    const tUs = tp.us;
+    while (si < src.length - 1 && (src[si + 1]?.us ?? tUs) <= tUs) si++;
+    const s0 = src[si];
+    const s1 = src[si + 1];
+    if (s0 && s1 && tUs >= s0.us && tUs <= s1.us && s1.us !== s0.us) {
+      const frac = (tUs - s0.us) / (s1.us - s0.us);
+      result.push(+(s0.v + frac * (s1.v - s0.v)).toFixed(3));
+    } else {
+      result.push(+(s0?.v ?? 0).toFixed(3));
+    }
+  }
+  return result;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,12 @@ importers:
       astro:
         specifier: ^6.1.9
         version: 6.1.9(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      chartjs-plugin-zoom:
+        specifier: ^2.2.0
+        version: 2.2.0(chart.js@4.5.1)
+      hammerjs:
+        specifier: ^2.0.8
+        version: 2.0.8
       idb:
         specifier: ^8.0.3
         version: 8.0.3
@@ -4442,6 +4448,9 @@ packages:
   '@types/gaussian@1.2.2':
     resolution: {integrity: sha512-FLlJb9oGcoq0xVaAmn5ytZWeEO4M7nfudewzqL6FxUUYLR5FB+hEzSYAsuhX7H7M6Mw/Z0rLbIVbQkMqHlRS7g==}
 
+  '@types/hammerjs@2.0.46':
+    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -5105,6 +5114,11 @@ packages:
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
+
+  chartjs-plugin-zoom@2.2.0:
+    resolution: {integrity: sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==}
+    peerDependencies:
+      chart.js: '>=3.2.0'
 
   chevrotain@10.5.0:
     resolution: {integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==}
@@ -6084,6 +6098,10 @@ packages:
 
   h3@1.15.10:
     resolution: {integrity: sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==}
+
+  hammerjs@2.0.8:
+    resolution: {integrity: sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==}
+    engines: {node: '>=0.8.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -12888,6 +12906,8 @@ snapshots:
 
   '@types/gaussian@1.2.2': {}
 
+  '@types/hammerjs@2.0.46': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -13701,6 +13721,12 @@ snapshots:
   chart.js@4.5.1:
     dependencies:
       '@kurkle/color': 0.3.4
+
+  chartjs-plugin-zoom@2.2.0(chart.js@4.5.1):
+    dependencies:
+      '@types/hammerjs': 2.0.46
+      chart.js: 4.5.1
+      hammerjs: 2.0.8
 
   chevrotain@10.5.0:
     dependencies:
@@ -14684,6 +14710,8 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.3
       uncrypto: 0.1.3
+
+  hammerjs@2.0.8: {}
 
   has-flag@4.0.0: {}
 


### PR DESCRIPTION
## Summary

- Adds **PDH Channels** as the 5th section in the analyzer nav bar
- Redesigned PDH section: subsystem list (left) + live chart (right) + drag-and-drop channel assignment zones (bottom)
- Subsystem rows support click-to-rename, color picker, collapsible channel list, per-subsystem avg/peak current stats, and a **Disband** button
- Rolling mean smoothing slider on the PDH chart
- Phase detection (toggleable): detects when each subsystem is active from channel current data and renders a timeline strip below the chart
- Export/Import PDH config as JSON for persistence across sessions
- Zoom/pan on all charts via scroll, drag-to-select, and shift+drag; minimum zoom limit prevents over-zooming
- File upload restricted to `.dslog` only; upload card enlarged and centered; WPILog hint card removed
- Per-channel toggle buttons removed from the Current section (kept only in PDH)
- Dev server HMR disabled to fix Vite 7/rolldown `moduleType` bug (no effect on production build)

## Test plan

- [ ] Upload a `.dslog` file and verify all 5 sections render
- [ ] Add subsystems, drag channels into them, verify chart updates
- [ ] Rename a subsystem and verify channel assignments follow the rename
- [ ] Disband a subsystem and verify channels return to Unassigned
- [ ] Export config, reload page, import config, verify state restored
- [ ] Enable phase detection and verify timeline strip appears below chart
- [ ] Scroll/drag to zoom on any chart; verify zoom stops at ~2–3 seconds minimum range
- [ ] Verify production build (`turbo build --filter=juice`) still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)